### PR TITLE
Remote key retrieval and interoperability fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default = [
     "use-blake2",
     "use-25519", 
     "use-pqclean-kyber",
-    "use-rust-crypto-kyber", 
+    "use-rust-crypto-ml-kem", 
 ]
 
 alloc = []
@@ -55,7 +55,7 @@ use-blake2 = ["blake2"]
 use-aes-gcm = ["aes-gcm"]
 use-chacha20poly1305 = ["chacha20poly1305"]
 use-pqclean-kyber = ["pqcrypto-kyber", "pqcrypto-traits"]
-use-rust-crypto-kyber = ["ml-kem"]
+use-rust-crypto-ml-kem = ["ml-kem"]
 use-25519 = ["x25519-dalek"]
 
 # docs.rs-specific configuration

--- a/examples/basic_dual_layer.rs
+++ b/examples/basic_dual_layer.rs
@@ -3,7 +3,7 @@ use core::str;
 use clatter::crypto::cipher::ChaChaPoly;
 use clatter::crypto::dh::X25519;
 use clatter::crypto::hash::Sha512;
-use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 use clatter::handshakepattern::{noise_nn, noise_pqnn};
 use clatter::traits::Handshaker;
 use clatter::{DualLayerHandshake, NqHandshake, PqHandshake};
@@ -38,7 +38,7 @@ fn main() {
     )
     .unwrap();
 
-    let alice_pq = PqHandshake::<Kyber512, Kyber512, ChaChaPoly, Sha512, _>::new(
+    let alice_pq = PqHandshake::<MlKem512, MlKem512, ChaChaPoly, Sha512, _>::new(
         noise_pqnn(),
         &[],
         true,
@@ -50,7 +50,7 @@ fn main() {
     )
     .unwrap();
 
-    let bob_pq = PqHandshake::<Kyber512, Kyber512, ChaChaPoly, Sha512, _>::new(
+    let bob_pq = PqHandshake::<MlKem512, MlKem512, ChaChaPoly, Sha512, _>::new(
         noise_pqnn(),
         &[],
         false,

--- a/examples/basic_pq.rs
+++ b/examples/basic_pq.rs
@@ -4,7 +4,7 @@ use clatter::crypto::cipher::ChaChaPoly;
 use clatter::crypto::hash::Sha512;
 use clatter::crypto::kem::pqclean_kyber::Kyber768;
 // We can mix and match KEMs from different vendors
-use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 use clatter::handshakepattern::noise_pqnn;
 use clatter::traits::Handshaker;
 use clatter::PqHandshake;
@@ -12,7 +12,7 @@ use clatter::PqHandshake;
 fn main() {
     let mut rng_alice = rand::thread_rng();
     let mut rng_bob = rand::thread_rng();
-    let mut alice = PqHandshake::<Kyber512, Kyber768, ChaChaPoly, Sha512, _>::new(
+    let mut alice = PqHandshake::<MlKem512, Kyber768, ChaChaPoly, Sha512, _>::new(
         noise_pqnn(),
         &[],
         true,
@@ -24,7 +24,7 @@ fn main() {
     )
     .unwrap();
 
-    let mut bob = PqHandshake::<Kyber512, Kyber768, ChaChaPoly, Sha512, _>::new(
+    let mut bob = PqHandshake::<MlKem512, Kyber768, ChaChaPoly, Sha512, _>::new(
         noise_pqnn(),
         &[],
         false,

--- a/examples/custom_crypto.rs
+++ b/examples/custom_crypto.rs
@@ -5,7 +5,7 @@ use clatter::bytearray::{ByteArray, SensitiveByteArray};
 use clatter::crypto::cipher::ChaChaPoly;
 use clatter::crypto::kem::pqclean_kyber::Kyber768;
 // We can mix and match KEMs from different vendors
-use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 use clatter::handshakepattern::noise_pqnn;
 use clatter::traits::Handshaker;
 use clatter::PqHandshake;
@@ -62,7 +62,7 @@ impl clatter::traits::Hash for MySillyHash {
 fn main() {
     let mut rng_alice = rand::thread_rng();
     let mut rng_bob = rand::thread_rng();
-    let mut alice = PqHandshake::<Kyber512, Kyber768, ChaChaPoly, MySillyHash, _>::new(
+    let mut alice = PqHandshake::<MlKem512, Kyber768, ChaChaPoly, MySillyHash, _>::new(
         noise_pqnn(),
         &[],
         true,
@@ -74,7 +74,7 @@ fn main() {
     )
     .unwrap();
 
-    let mut bob = PqHandshake::<Kyber512, Kyber768, ChaChaPoly, MySillyHash, _>::new(
+    let mut bob = PqHandshake::<MlKem512, Kyber768, ChaChaPoly, MySillyHash, _>::new(
         noise_pqnn(),
         &[],
         false,

--- a/fuzz/fuzz_targets/pq_handshake_payload.rs
+++ b/fuzz/fuzz_targets/pq_handshake_payload.rs
@@ -5,7 +5,7 @@ use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::pqclean_kyber::Kyber768;
-use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Hash, Kem};
 use clatter::{Handshaker, PqHandshake};
@@ -13,14 +13,14 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     // TODO: generate all combinations
-    verify_with::<Kyber768, Kyber512, AesGcm, Sha256>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Sha512>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Blake2b>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Blake2s>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Sha256>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Sha512>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Blake2b>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Sha256>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Sha512>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Blake2s>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Sha256>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Sha512>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Blake2b>(data);
 });
 
 fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {

--- a/fuzz/fuzz_targets/pq_handshake_read.rs
+++ b/fuzz/fuzz_targets/pq_handshake_read.rs
@@ -5,7 +5,7 @@ use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::pqclean_kyber::Kyber768;
-use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Hash, Kem};
 use clatter::{Handshaker, PqHandshake};
@@ -13,14 +13,14 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     // TODO: generate all combinations
-    verify_with::<Kyber768, Kyber512, AesGcm, Sha256>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Sha512>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Blake2b>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Blake2s>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Sha256>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Sha512>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Blake2b>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Sha256>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Sha512>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Blake2s>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Sha256>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Sha512>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Blake2b>(data);
 });
 
 fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {

--- a/fuzz/fuzz_targets/pq_transport.rs
+++ b/fuzz/fuzz_targets/pq_transport.rs
@@ -5,7 +5,7 @@ use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::pqclean_kyber::Kyber768;
-use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Hash, Kem};
 use clatter::{Handshaker, PqHandshake};
@@ -13,14 +13,14 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     // TODO: generate all combinations
-    verify_with::<Kyber768, Kyber512, AesGcm, Sha256>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Sha512>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Blake2b>(data);
-    verify_with::<Kyber768, Kyber512, AesGcm, Blake2s>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Sha256>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Sha512>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Blake2b>(data);
-    verify_with::<Kyber768, Kyber512, ChaChaPoly, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Sha256>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Sha512>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, AesGcm, Blake2s>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Sha256>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Sha512>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<Kyber768, MlKem512, ChaChaPoly, Blake2b>(data);
 });
 
 fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {

--- a/src/crypto_impl/mod.rs
+++ b/src/crypto_impl/mod.rs
@@ -10,8 +10,8 @@ pub mod sha;
 #[cfg(feature = "use-pqclean-kyber")]
 pub mod pqclean_kyber;
 
-#[cfg(feature = "use-rust-crypto-kyber")]
-pub mod rust_crypto_kyber;
+#[cfg(feature = "use-rust-crypto-ml-kem")]
+pub mod rust_crypto_ml_kem;
 
 // Ciphers
 #[cfg(feature = "use-aes-gcm")]

--- a/src/crypto_impl/rust_crypto_ml_kem.rs
+++ b/src/crypto_impl/rust_crypto_ml_kem.rs
@@ -1,4 +1,4 @@
-//! Kyber implementation by RustCrypto: https://github.com/RustCrypto/KEMs
+//! ML-KEM implementation by RustCrypto: https://github.com/RustCrypto/KEMs
 
 use ml_kem::kem::{Decapsulate, DecapsulationKey, Encapsulate, EncapsulationKey};
 use ml_kem::{EncodedSizeUser, KemCore, MlKem1024Params, MlKem512Params, MlKem768Params};
@@ -9,34 +9,34 @@ use crate::error::KemError;
 use crate::traits::{CryptoComponent, Kem};
 use crate::KeyPair;
 
-/// Kyber512 KEM implementation
-pub struct Kyber512;
-/// Kyber768 KEM implementation
-pub struct Kyber768;
-/// Kyber1024 KEM implementation
-pub struct Kyber1024;
+/// ML-KEM-512 KEM implementation
+pub struct MlKem512;
+/// ML-KEM-768 KEM implementation
+pub struct MlKem768;
+/// ML-KEM-1024 KEM implementation
+pub struct MlKem1024;
 
-impl CryptoComponent for Kyber512 {
+impl CryptoComponent for MlKem512 {
     fn name() -> &'static str {
-        "Kyber512"
+        "MLKEM512"
     }
 }
 
-impl CryptoComponent for Kyber768 {
+impl CryptoComponent for MlKem768 {
     fn name() -> &'static str {
-        "Kyber768"
+        "MLKEM768"
     }
 }
 
-impl CryptoComponent for Kyber1024 {
+impl CryptoComponent for MlKem1024 {
     fn name() -> &'static str {
-        "Kyber1024"
+        "MLKEM1024"
     }
 }
 
-macro_rules! impl_kyber {
-    ($kyber:ty, $params:ty, $sk:expr, $pk:expr, $ct:expr) => {
-        impl Kem for $kyber {
+macro_rules! impl_ml_kem {
+    ($ml_kem:ty, $params:ty, $sk:expr, $pk:expr, $ct:expr) => {
+        impl Kem for $ml_kem {
             #[cfg(feature = "alloc")]
             type SecretKey = SensitiveByteArray<crate::bytearray::HeapArray<$sk>>;
             #[cfg(not(feature = "alloc"))]
@@ -95,6 +95,6 @@ macro_rules! impl_kyber {
     };
 }
 
-impl_kyber!(Kyber512, MlKem512Params, 1632, 800, 768);
-impl_kyber!(Kyber768, MlKem768Params, 2400, 1184, 1088);
-impl_kyber!(Kyber1024, MlKem1024Params, 3168, 1568, 1568);
+impl_ml_kem!(MlKem512, MlKem512Params, 1632, 800, 768);
+impl_ml_kem!(MlKem768, MlKem768Params, 2400, 1184, 1088);
+impl_ml_kem!(MlKem1024, MlKem1024Params, 3168, 1568, 1568);

--- a/src/handshakestate/dual_layer.rs
+++ b/src/handshakestate/dual_layer.rs
@@ -75,6 +75,26 @@ where
         self.outer_is_finished
     }
 
+    /// Get reference to inner handshake
+    pub fn inner(&self) -> &Inner {
+        &self.inner
+    }
+
+    /// Get mutable reference to inner handshake
+    pub fn inner_mut(&mut self) -> &mut Inner {
+        &mut self.inner
+    }
+
+    /// Get reference to outer handshake
+    pub fn outer(&self) -> Option<&Outer> {
+        self.outer.as_ref()
+    }
+
+    /// Get mutable reference to outer handshake
+    pub fn outer_mut(&mut self) -> Option<&mut Outer> {
+        self.outer.as_mut()
+    }
+
     fn update_outer_state(&mut self) -> HandshakeResult<()> {
         if self.outer.as_ref().unwrap().is_finished() {
             self.outer_transport = Some(self.outer.take().unwrap().finalize()?);
@@ -177,6 +197,9 @@ where
     C: Cipher,
     H: Hash,
 {
+    type E = Inner::E;
+    type S = Inner::S;
+
     fn push_psk(&mut self, _psk: &[u8]) {
         panic!("Not applicable for dual-layer handshakes");
     }
@@ -203,5 +226,15 @@ where
 
     fn build_name(_: &crate::handshakepattern::HandshakePattern) -> arrayvec::ArrayString<128> {
         panic!("Not applicable for dual-layer handshakes");
+    }
+
+    /// Get remote static key of the **inner** handshake (if available)
+    fn get_remote_static(&self) -> Option<Self::S> {
+        self.inner.get_remote_static()
+    }
+
+    /// Get remote ephemeral key of the **inner** handshake (if available)
+    fn get_remote_ephemeral(&self) -> Option<Self::E> {
+        self.inner.get_remote_ephemeral()
     }
 }

--- a/src/handshakestate/nq.rs
+++ b/src/handshakestate/nq.rs
@@ -399,6 +399,9 @@ where
     H: Hash,
     RNG: RngCore + CryptoRng,
 {
+    type E = DH::PubKey;
+    type S = DH::PubKey;
+
     fn push_psk(&mut self, psk: &[u8]) {
         self.internals.push_psk(psk);
     }
@@ -459,5 +462,13 @@ where
         )
         .unwrap();
         ret
+    }
+
+    fn get_remote_static(&self) -> Option<Self::S> {
+        self.internals.rs.as_ref().map(|rs| rs.clone())
+    }
+
+    fn get_remote_ephemeral(&self) -> Option<Self::E> {
+        self.internals.re.as_ref().map(|re| re.clone())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! | `use-chacha20poly1305`    | Enable ChaCha20-Poly1305 cipher           | yes       |                                           |
 //! | `use-sha`                 | Enable SHA-256 and SHA-512 hashing        | yes       |                                           |
 //! | `use-blake2`              | Enable BLAKE2 hashing                     | yes       |                                           |
-//! | `use-rust-crypto-kyber`   | Enable Kyber KEMs by RustCrypto           | yes       |                                           |
+//! | `use-rust-crypto-ml-kem`  | Enable ML-KEM (Kyber) KEMs by RustCrypto  | yes       |                                           |
 //! | `use-pqclean-kyber`       | Enable Kyber KEMs by PQClean              | yes       |                                           |
 //! | `std`                     | Enable standard library support           | no        | Enables `std` for supported dependencies  |
 //! | `alloc`                   | Enable allocator support                  | no        |                                           |
@@ -68,7 +68,7 @@
 //! ```no_run
 //! use clatter::crypto::cipher::ChaChaPoly;
 //! use clatter::crypto::hash::Sha512;
-//! use clatter::crypto::kem::rust_crypto_kyber::Kyber512;
+//! use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
 //! use clatter::handshakepattern::noise_pqnn;
 //! use clatter::traits::Handshaker;
 //! use clatter::PqHandshake;
@@ -76,7 +76,7 @@
 //! let mut rng_alice = rand::thread_rng();
 //!
 //! // Instantiate initiator handshake
-//! let mut alice = PqHandshake::<Kyber512, Kyber512, ChaChaPoly, Sha512, _>::new(
+//! let mut alice = PqHandshake::<MlKem512, MlKem512, ChaChaPoly, Sha512, _>::new(
 //!     noise_pqnn(),   // Handshake pattern
 //!     &[],            // Prologue data
 //!     true,           // Are we the initiator
@@ -144,9 +144,9 @@ pub mod crypto {
         #[cfg_attr(docsrs, doc(cfg(feature = "use-pqclean-kyber")))]
         #[cfg(feature = "use-pqclean-kyber")]
         pub use crate::crypto_impl::pqclean_kyber;
-        #[cfg_attr(docsrs, doc(cfg(feature = "use-rust-crypto-kyber")))]
-        #[cfg(feature = "use-rust-crypto-kyber")]
-        pub use crate::crypto_impl::rust_crypto_kyber;
+        #[cfg_attr(docsrs, doc(cfg(feature = "use-rust-crypto-ml-kem")))]
+        #[cfg(feature = "use-rust-crypto-ml-kem")]
+        pub use crate::crypto_impl::rust_crypto_ml_kem;
     }
 
     /// Supported DH algorithms

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -273,6 +273,11 @@ where
     C: Cipher,
     H: Hash,
 {
+    /// Ephemeral public key type
+    type E: ByteArray;
+    /// Static public key type
+    type S: ByteArray;
+
     /// Write next handshake message to the given buffer
     ///
     /// # Arguments
@@ -398,6 +403,12 @@ where
     fn get_name(&self) -> ArrayString<128> {
         Self::build_name(&self.get_pattern())
     }
+
+    /// Get remote static key (if available)
+    fn get_remote_static(&self) -> Option<Self::S>;
+
+    /// Get remote ephemeral key (if available)
+    fn get_remote_ephemeral(&self) -> Option<Self::E>;
 
     /// Transition into transport mode
     ///

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -4,7 +4,7 @@ use clatter::bytearray::ByteArray;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::dh::X25519;
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
-use clatter::crypto::kem::{pqclean_kyber, rust_crypto_kyber};
+use clatter::crypto::kem::{pqclean_kyber, rust_crypto_ml_kem};
 use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Dh, Hash, Kem};
 use clatter::{DualLayerHandshake, Handshaker, NqHandshake, PqHandshake};
@@ -114,13 +114,13 @@ fn smoke_pq_handshakes() {
 
     for pattern in handshakes {
         // Rust crypto
-        cipher_hash_combos::<rust_crypto_kyber::Kyber512, rust_crypto_kyber::Kyber512>(
+        cipher_hash_combos::<rust_crypto_ml_kem::MlKem512, rust_crypto_ml_kem::MlKem512>(
             pattern.clone(),
         );
-        cipher_hash_combos::<rust_crypto_kyber::Kyber768, rust_crypto_kyber::Kyber768>(
+        cipher_hash_combos::<rust_crypto_ml_kem::MlKem768, rust_crypto_ml_kem::MlKem768>(
             pattern.clone(),
         );
-        cipher_hash_combos::<rust_crypto_kyber::Kyber1024, rust_crypto_kyber::Kyber1024>(
+        cipher_hash_combos::<rust_crypto_ml_kem::MlKem1024, rust_crypto_ml_kem::MlKem1024>(
             pattern.clone(),
         );
 
@@ -130,7 +130,9 @@ fn smoke_pq_handshakes() {
         cipher_hash_combos::<pqclean_kyber::Kyber1024, pqclean_kyber::Kyber1024>(pattern.clone());
 
         // One cross-use test just in case with two different KEM vendors
-        cipher_hash_combos::<pqclean_kyber::Kyber768, rust_crypto_kyber::Kyber768>(pattern.clone());
+        cipher_hash_combos::<pqclean_kyber::Kyber768, rust_crypto_ml_kem::MlKem768>(
+            pattern.clone(),
+        );
     }
 }
 
@@ -253,18 +255,19 @@ fn smoke_dual_layer_handshakes() {
         }
         for pq in &pq_handshakes {
             // Rust crypto
-            cipher_hash_combos::<rust_crypto_kyber::Kyber512, rust_crypto_kyber::Kyber512, X25519>(
+            cipher_hash_combos::<rust_crypto_ml_kem::MlKem512, rust_crypto_ml_kem::MlKem512, X25519>(
                 nq.clone(),
                 pq.clone(),
             );
-            cipher_hash_combos::<rust_crypto_kyber::Kyber768, rust_crypto_kyber::Kyber768, X25519>(
+            cipher_hash_combos::<rust_crypto_ml_kem::MlKem768, rust_crypto_ml_kem::MlKem768, X25519>(
                 nq.clone(),
                 pq.clone(),
             );
-            cipher_hash_combos::<rust_crypto_kyber::Kyber1024, rust_crypto_kyber::Kyber1024, X25519>(
-                nq.clone(),
-                pq.clone(),
-            );
+            cipher_hash_combos::<
+                rust_crypto_ml_kem::MlKem1024,
+                rust_crypto_ml_kem::MlKem1024,
+                X25519,
+            >(nq.clone(), pq.clone());
 
             // PQCLean
             cipher_hash_combos::<pqclean_kyber::Kyber512, pqclean_kyber::Kyber512, X25519>(
@@ -281,7 +284,7 @@ fn smoke_dual_layer_handshakes() {
             );
 
             // One cross-use test just in case with two different KEM vendors
-            cipher_hash_combos::<pqclean_kyber::Kyber768, rust_crypto_kyber::Kyber768, X25519>(
+            cipher_hash_combos::<pqclean_kyber::Kyber768, rust_crypto_ml_kem::MlKem768, X25519>(
                 nq.clone(),
                 pq.clone(),
             );


### PR DESCRIPTION
* Added the posibility to retrieve peer ephemeral or static key from handshake state
* Renamed RustCrypto Kyber wrapper to ML-KEM
* Modified PQ protocol name formation for compatibility with Nyquist
* Added related documentation updates