### PR TITLE
Test restructuring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "clatter"
-version = "2.1.0-rc.1"
+version = "2.1.0-rc.2"
 dependencies = [
  "aes-gcm",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clatter"
-version = "2.1.0-rc.1"
+version = "2.1.0-rc.2"
 edition = "2021"
 rust-version = "1.81.0"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with support for [**Post Quantum (PQ) extensions**](https://doi.org/10.1145/3548
 Yawning Angel, Benjamin Dowling, Andreas Hülsing, Peter Schwabe, and Fiona Johanna Weber.
 
 Main targets of this crate are **correctness**, extensibility, and strict `no_std` compatibility
-and those come  with the small drawback of more verbose user experience with some boilerplate.
+and those come with the small drawback of more verbose user experience with some boilerplate.
 If you don't need PQ functionality and are developing for a regular target, you probably are better
 off using these instead:
 
@@ -106,7 +106,7 @@ Thus Clatter proposes and uses the following naming scheme:
 | ML-KEM-768    | `MLKEM768`    |
 | ML-KEM-1024   | `MLKEM1024`   |
 
-Clatter also includes the possibility to pick different KEMs for ehpemeral and static operations. If the
+Clatter also includes the possibility to pick different KEMs for ephemeral and static operations. If the
 same KEM is used for both, the name of the KEM is simply placed in the protocol name in place of the DH algorithm.
 
 Examples:
@@ -195,7 +195,7 @@ the final transport keys only derive entropy from the inner handshake.
 
 ## Verification
 
-Caltter is verified by:
+Clatter is verified by:
 
 * Unit tests
 * [Smoke tests](tests/)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
+[lib]
+name = "clatter_fuzz"
+path = "src/lib.rs"
+
 [dependencies]
 libfuzzer-sys = "0.4"
 rand = "0.8.5"
@@ -52,6 +56,27 @@ bench = false
 [[bin]]
 name = "pq_transport"
 path = "fuzz_targets/pq_transport.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "hybrid_handshake_read"
+path = "fuzz_targets/hybrid_handshake_read.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "hybrid_handshake_payload"
+path = "fuzz_targets/hybrid_handshake_payload.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "hybrid_transport"
+path = "fuzz_targets/hybrid_transport.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/hybrid_handshake_payload.rs
+++ b/fuzz/fuzz_targets/hybrid_handshake_payload.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+use clatter::constants::MAX_MESSAGE_LEN;
+use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
+use clatter::crypto::dh::X25519;
+use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
+use clatter::crypto::kem::pqclean_ml_kem::MlKem1024;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
+use clatter::traits::{Cipher, Dh, Hash, Handshaker, Kem};
+use clatter_fuzz::{hybrid_handshake_patterns, setup_hybrid_handshake};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Sha256>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Sha512>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Blake2s>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Sha256>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Sha512>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Blake2s>(data);
+});
+
+fn verify_with<DH: Dh, EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
+    let handshakes = hybrid_handshake_patterns();
+
+    for pattern in handshakes {
+        let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
+
+        let (mut alice, _) = setup_hybrid_handshake::<DH, EKEM, SKEM, C, H>(&pattern);
+
+        // Alice writes fuzzed payload
+        let _ = alice.write_message(data, &mut alice_buf);
+    }
+}
+

--- a/fuzz/fuzz_targets/hybrid_handshake_read.rs
+++ b/fuzz/fuzz_targets/hybrid_handshake_read.rs
@@ -1,0 +1,41 @@
+#![no_main]
+
+use clatter::constants::MAX_MESSAGE_LEN;
+use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
+use clatter::crypto::dh::X25519;
+use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
+use clatter::crypto::kem::pqclean_ml_kem::MlKem1024;
+use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
+use clatter::traits::{Cipher, Dh, Hash, Handshaker, Kem};
+use clatter_fuzz::{hybrid_handshake_patterns, setup_hybrid_handshake};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Sha256>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Sha512>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Blake2s>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Sha256>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Sha512>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Blake2s>(data);
+});
+
+fn verify_with<DH: Dh, EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
+    let handshakes = hybrid_handshake_patterns();
+
+    for pattern in handshakes {
+        let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
+        let mut bob_buf = [0u8; MAX_MESSAGE_LEN];
+
+        let (mut alice, mut bob) = setup_hybrid_handshake::<DH, EKEM, SKEM, C, H>(&pattern);
+
+        // Verify Alice only if the pattern is not one-way
+        if !pattern.is_one_way() {
+            let _ = alice.write_message(&[], &mut alice_buf).unwrap();
+            let _ = alice.read_message(data, &mut alice_buf);
+        }
+        let _ = bob.read_message(data, &mut bob_buf);
+    }
+}
+

--- a/fuzz/fuzz_targets/hybrid_transport.rs
+++ b/fuzz/fuzz_targets/hybrid_transport.rs
@@ -2,33 +2,33 @@
 
 use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
+use clatter::crypto::dh::X25519;
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::pqclean_ml_kem::MlKem1024;
 use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
-use clatter::traits::{Cipher, Hash, Kem};
-use clatter_fuzz::{complete_handshake, pq_handshake_patterns, setup_pq_handshake};
+use clatter::traits::{Cipher, Dh, Hash, Kem};
+use clatter_fuzz::{complete_handshake, hybrid_handshake_patterns, setup_hybrid_handshake};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    // TODO: generate all combinations
-    verify_with::<MlKem1024, MlKem512, AesGcm, Sha256>(data);
-    verify_with::<MlKem1024, MlKem512, AesGcm, Sha512>(data);
-    verify_with::<MlKem1024, MlKem512, AesGcm, Blake2b>(data);
-    verify_with::<MlKem1024, MlKem512, AesGcm, Blake2s>(data);
-    verify_with::<MlKem1024, MlKem512, ChaChaPoly, Sha256>(data);
-    verify_with::<MlKem1024, MlKem512, ChaChaPoly, Sha512>(data);
-    verify_with::<MlKem1024, MlKem512, ChaChaPoly, Blake2b>(data);
-    verify_with::<MlKem1024, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Sha256>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Sha512>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, AesGcm, Blake2s>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Sha256>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Sha512>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Blake2b>(data);
+    verify_with::<X25519, MlKem1024, MlKem512, ChaChaPoly, Blake2s>(data);
 });
 
-fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
-    let handshakes = pq_handshake_patterns();
+fn verify_with<DH: Dh, EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
+    let handshakes = hybrid_handshake_patterns();
 
     for pattern in handshakes {
         let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
         let mut bob_buf = [0u8; MAX_MESSAGE_LEN];
 
-        let (alice, bob) = setup_pq_handshake::<EKEM, SKEM, C, H>(&pattern);
+        let (alice, bob) = setup_hybrid_handshake::<DH, EKEM, SKEM, C, H>(&pattern);
 
         // Complete handshake
         let (mut alice, mut bob) = complete_handshake(alice, bob);
@@ -48,3 +48,4 @@ fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
         }
     }
 }
+

--- a/fuzz/fuzz_targets/nq_handshake_payload.rs
+++ b/fuzz/fuzz_targets/nq_handshake_payload.rs
@@ -4,9 +4,8 @@ use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::dh::X25519;
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
-use clatter::handshakepattern::*;
-use clatter::traits::{Cipher, Dh, Hash};
-use clatter::{Handshaker, NqHandshake};
+use clatter::traits::{Cipher, Dh, Hash, Handshaker};
+use clatter_fuzz::{nq_handshake_patterns, setup_nq_handshake};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -21,66 +20,12 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn verify_with<DH: Dh, C: Cipher, H: Hash>(data: &[u8]) {
-    let handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
-
-    const PSK: &[u8] = b"Trapped inside this Octavarium!!";
+    let handshakes = nq_handshake_patterns();
 
     for pattern in handshakes {
         let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
 
-        let alice_key = DH::genkey().unwrap();
-        let bob_key = DH::genkey().unwrap();
-        let bob_pub = bob_key.public.clone();
-
-        let mut alice = NqHandshake::<DH, C, H>::new(
-            pattern.clone(),
-            &[],
-            true,
-            Some(alice_key),
-            None,
-            Some(bob_pub),
-            None,
-        )
-        .unwrap();
-
-        alice.push_psk(PSK);
+        let (mut alice, _) = setup_nq_handshake::<DH, C, H>(&pattern);
 
         // Alice writes fuzzed payload
         let _ = alice.write_message(data, &mut alice_buf);

--- a/fuzz/fuzz_targets/nq_handshake_read.rs
+++ b/fuzz/fuzz_targets/nq_handshake_read.rs
@@ -4,9 +4,8 @@ use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::dh::X25519;
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
-use clatter::handshakepattern::*;
-use clatter::traits::{Cipher, Dh, Hash};
-use clatter::{Handshaker, NqHandshake};
+use clatter::traits::{Cipher, Dh, Hash, Handshaker};
+use clatter_fuzz::{nq_handshake_patterns, setup_nq_handshake};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -21,79 +20,13 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn verify_with<DH: Dh, C: Cipher, H: Hash>(data: &[u8]) {
-    let handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
-
-    const PSK: &[u8] = b"Trapped inside this Octavarium!!";
+    let handshakes = nq_handshake_patterns();
 
     for pattern in handshakes {
         let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
         let mut bob_buf = [0u8; MAX_MESSAGE_LEN];
 
-        let alice_key = DH::genkey().unwrap();
-        let bob_key = DH::genkey().unwrap();
-        let alice_pub = alice_key.public.clone();
-        let bob_pub = bob_key.public.clone();
-
-        let mut alice = NqHandshake::<DH, C, H>::new(
-            pattern.clone(),
-            &[],
-            true,
-            Some(alice_key),
-            None,
-            Some(bob_pub),
-            None,
-        )
-        .unwrap();
-        let mut bob = NqHandshake::<DH, C, H>::new(
-            pattern.clone(),
-            &[],
-            false,
-            Some(bob_key),
-            None,
-            Some(alice_pub),
-            None,
-        )
-        .unwrap();
-
-        alice.push_psk(PSK);
-        bob.push_psk(PSK);
+        let (mut alice, mut bob) = setup_nq_handshake::<DH, C, H>(&pattern);
 
         // Verify Alice only if the pattern is not one-way
         if !pattern.is_one_way() {

--- a/fuzz/fuzz_targets/nq_transport.rs
+++ b/fuzz/fuzz_targets/nq_transport.rs
@@ -4,9 +4,8 @@ use clatter::constants::MAX_MESSAGE_LEN;
 use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::dh::X25519;
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
-use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Dh, Hash};
-use clatter::{Handshaker, NqHandshake};
+use clatter_fuzz::{complete_handshake, nq_handshake_patterns, setup_nq_handshake};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -21,100 +20,16 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn verify_with<DH: Dh, C: Cipher, H: Hash>(data: &[u8]) {
-    let handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
-
-    const PSK: &[u8] = b"Trapped inside this Octavarium!!";
+    let handshakes = nq_handshake_patterns();
 
     for pattern in handshakes {
         let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
         let mut bob_buf = [0u8; MAX_MESSAGE_LEN];
 
-        let alice_key = DH::genkey().unwrap();
-        let bob_key = DH::genkey().unwrap();
-        let alice_pub = alice_key.public.clone();
-        let bob_pub = bob_key.public.clone();
-
-        let mut alice = NqHandshake::<DH, C, H>::new(
-            pattern.clone(),
-            &[],
-            true,
-            Some(alice_key),
-            None,
-            Some(bob_pub),
-            None,
-        )
-        .unwrap();
-        let mut bob = NqHandshake::<DH, C, H>::new(
-            pattern.clone(),
-            &[],
-            false,
-            Some(bob_key),
-            None,
-            Some(alice_pub),
-            None,
-        )
-        .unwrap();
-
-        alice.push_psk(PSK);
-        bob.push_psk(PSK);
+        let (alice, bob) = setup_nq_handshake::<DH, C, H>(&pattern);
 
         // Complete handshake
-        loop {
-            let n = alice.write_message(&[], &mut alice_buf).unwrap();
-            let _ = bob.read_message(&alice_buf[..n], &mut bob_buf).unwrap();
-
-            if alice.is_finished() && bob.is_finished() {
-                break;
-            }
-
-            let n = bob.write_message(&[], &mut bob_buf).unwrap();
-            let _ = alice.read_message(&bob_buf[..n], &mut alice_buf).unwrap();
-
-            if alice.is_finished() && bob.is_finished() {
-                break;
-            }
-        }
-
-        // Handshake done
-        let mut alice = alice.finalize().unwrap();
-        let mut bob = bob.finalize().unwrap();
+        let (mut alice, mut bob) = complete_handshake(alice, bob);
 
         if !pattern.is_one_way() {
             // Both receive fuzzed data

--- a/fuzz/fuzz_targets/pq_handshake_payload.rs
+++ b/fuzz/fuzz_targets/pq_handshake_payload.rs
@@ -5,9 +5,8 @@ use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::pqclean_ml_kem::MlKem1024;
 use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
-use clatter::handshakepattern::*;
-use clatter::traits::{Cipher, Hash, Kem};
-use clatter::{Handshaker, PqHandshake};
+use clatter::traits::{Cipher, Hash, Handshaker, Kem};
+use clatter_fuzz::{pq_handshake_patterns, setup_pq_handshake};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -23,60 +22,12 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
-    let handshakes = [
-        noise_pqik(),
-        noise_pqin(),
-        noise_pqix(),
-        noise_pqkk(),
-        noise_pqkn(),
-        noise_pqkx(),
-        noise_pqnk(),
-        noise_pqnn(),
-        noise_pqnx(),
-        noise_pqxk(),
-        noise_pqxn(),
-        noise_pqxx(),
-        noise_pqik_psk1(),
-        noise_pqik_psk2(),
-        noise_pqin_psk1(),
-        noise_pqin_psk2(),
-        noise_pqix_psk2(),
-        noise_pqkk_psk0(),
-        noise_pqkk_psk2(),
-        noise_pqkn_psk0(),
-        noise_pqkn_psk2(),
-        noise_pqkx_psk2(),
-        noise_pqnk_psk0(),
-        noise_pqnk_psk2(),
-        noise_pqnn_psk0(),
-        noise_pqnn_psk2(),
-        noise_pqnx_psk2(),
-        noise_pqxk_psk3(),
-        noise_pqxn_psk3(),
-        noise_pqxx_psk3(),
-    ];
-
-    const PSK: &[u8] = b"Trapped inside this Octavarium!!";
+    let handshakes = pq_handshake_patterns();
 
     for pattern in handshakes {
         let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
 
-        let alice_key = SKEM::genkey().unwrap();
-        let bob_key = SKEM::genkey().unwrap();
-        let bob_pub = bob_key.public.clone();
-
-        let mut alice = PqHandshake::<EKEM, SKEM, C, H>::new(
-            pattern.clone(),
-            &[],
-            true,
-            Some(alice_key),
-            None,
-            Some(bob_pub),
-            None,
-        )
-        .unwrap();
-
-        alice.push_psk(PSK);
+        let (mut alice, _) = setup_pq_handshake::<EKEM, SKEM, C, H>(&pattern);
 
         // Alice writes fuzzed payload
         let _ = alice.write_message(data, &mut alice_buf);

--- a/fuzz/fuzz_targets/pq_handshake_read.rs
+++ b/fuzz/fuzz_targets/pq_handshake_read.rs
@@ -5,9 +5,8 @@ use clatter::crypto::cipher::{AesGcm, ChaChaPoly};
 use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::pqclean_ml_kem::MlKem1024;
 use clatter::crypto::kem::rust_crypto_ml_kem::MlKem512;
-use clatter::handshakepattern::*;
-use clatter::traits::{Cipher, Hash, Kem};
-use clatter::{Handshaker, PqHandshake};
+use clatter::traits::{Cipher, Hash, Handshaker, Kem};
+use clatter_fuzz::{pq_handshake_patterns, setup_pq_handshake};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -23,73 +22,13 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn verify_with<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(data: &[u8]) {
-    let handshakes = [
-        noise_pqik(),
-        noise_pqin(),
-        noise_pqix(),
-        noise_pqkk(),
-        noise_pqkn(),
-        noise_pqkx(),
-        noise_pqnk(),
-        noise_pqnn(),
-        noise_pqnx(),
-        noise_pqxk(),
-        noise_pqxn(),
-        noise_pqxx(),
-        noise_pqik_psk1(),
-        noise_pqik_psk2(),
-        noise_pqin_psk1(),
-        noise_pqin_psk2(),
-        noise_pqix_psk2(),
-        noise_pqkk_psk0(),
-        noise_pqkk_psk2(),
-        noise_pqkn_psk0(),
-        noise_pqkn_psk2(),
-        noise_pqkx_psk2(),
-        noise_pqnk_psk0(),
-        noise_pqnk_psk2(),
-        noise_pqnn_psk0(),
-        noise_pqnn_psk2(),
-        noise_pqnx_psk2(),
-        noise_pqxk_psk3(),
-        noise_pqxn_psk3(),
-        noise_pqxx_psk3(),
-    ];
-
-    const PSK: &[u8] = b"Trapped inside this Octavarium!!";
+    let handshakes = pq_handshake_patterns();
 
     for pattern in handshakes {
         let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
         let mut bob_buf = [0u8; MAX_MESSAGE_LEN];
 
-        let alice_key = SKEM::genkey().unwrap();
-        let bob_key = SKEM::genkey().unwrap();
-        let alice_pub = alice_key.public.clone();
-        let bob_pub = bob_key.public.clone();
-
-        let mut alice = PqHandshake::<EKEM, SKEM, C, H>::new(
-            pattern.clone(),
-            &[],
-            true,
-            Some(alice_key),
-            None,
-            Some(bob_pub),
-            None,
-        )
-        .unwrap();
-        let mut bob = PqHandshake::<EKEM, SKEM, C, H>::new(
-            pattern.clone(),
-            &[],
-            false,
-            Some(bob_key),
-            None,
-            Some(alice_pub),
-            None,
-        )
-        .unwrap();
-
-        alice.push_psk(PSK);
-        bob.push_psk(PSK);
+        let (mut alice, mut bob) = setup_pq_handshake::<EKEM, SKEM, C, H>(&pattern);
 
         // Verify Alice only if the pattern is not one-way
         if !pattern.is_one_way() {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,266 @@
+//! Shared utilities for fuzz testing
+
+use clatter::constants::MAX_MESSAGE_LEN;
+use clatter::handshakepattern::*;
+use clatter::traits::{Cipher, Dh, Hash, Handshaker, Kem};
+use clatter::transportstate::TransportState;
+use clatter::{HybridHandshake, HybridHandshakeParams, NqHandshake, PqHandshake};
+
+/// Common PSK used in fuzz tests
+pub const PSK: &[u8] = b"Trapped inside this Octavarium!!";
+
+/// Get all NQ handshake patterns
+pub fn nq_handshake_patterns() -> Vec<HandshakePattern> {
+    vec![
+        noise_n(),
+        noise_k(),
+        noise_x(),
+        noise_ik(),
+        noise_in(),
+        noise_ix(),
+        noise_kk(),
+        noise_kn(),
+        noise_kx(),
+        noise_nk(),
+        noise_nn(),
+        noise_nx(),
+        noise_xk(),
+        noise_xn(),
+        noise_xx(),
+        noise_n_psk0(),
+        noise_k_psk0(),
+        noise_x_psk1(),
+        noise_ik_psk1(),
+        noise_ik_psk2(),
+        noise_in_psk1(),
+        noise_in_psk2(),
+        noise_ix_psk2(),
+        noise_kk_psk0(),
+        noise_kk_psk2(),
+        noise_kn_psk0(),
+        noise_kn_psk2(),
+        noise_kx_psk2(),
+        noise_nk_psk0(),
+        noise_nk_psk2(),
+        noise_nn_psk0(),
+        noise_nn_psk2(),
+        noise_nx_psk2(),
+        noise_xk_psk3(),
+        noise_xn_psk3(),
+        noise_xx_psk3(),
+    ]
+}
+
+/// Get all PQ handshake patterns
+pub fn pq_handshake_patterns() -> Vec<HandshakePattern> {
+    vec![
+        noise_pqik(),
+        noise_pqin(),
+        noise_pqix(),
+        noise_pqkk(),
+        noise_pqkn(),
+        noise_pqkx(),
+        noise_pqnk(),
+        noise_pqnn(),
+        noise_pqnx(),
+        noise_pqxk(),
+        noise_pqxn(),
+        noise_pqxx(),
+        noise_pqik_psk1(),
+        noise_pqik_psk2(),
+        noise_pqin_psk1(),
+        noise_pqin_psk2(),
+        noise_pqix_psk2(),
+        noise_pqkk_psk0(),
+        noise_pqkk_psk2(),
+        noise_pqkn_psk0(),
+        noise_pqkn_psk2(),
+        noise_pqkx_psk2(),
+        noise_pqnk_psk0(),
+        noise_pqnk_psk2(),
+        noise_pqnn_psk0(),
+        noise_pqnn_psk2(),
+        noise_pqnx_psk2(),
+        noise_pqxk_psk3(),
+        noise_pqxn_psk3(),
+        noise_pqxx_psk3(),
+    ]
+}
+
+/// Get all hybrid handshake patterns
+pub fn hybrid_handshake_patterns() -> Vec<HandshakePattern> {
+    vec![
+        noise_hybrid_ik(),
+        noise_hybrid_in(),
+        noise_hybrid_ix(),
+        noise_hybrid_kk(),
+        noise_hybrid_kn(),
+        noise_hybrid_kx(),
+        noise_hybrid_nk(),
+        noise_hybrid_nn(),
+        noise_hybrid_nx(),
+        noise_hybrid_xk(),
+        noise_hybrid_xn(),
+        noise_hybrid_xx(),
+        noise_hybrid_ik_psk1(),
+        noise_hybrid_ik_psk2(),
+        noise_hybrid_in_psk1(),
+        noise_hybrid_in_psk2(),
+        noise_hybrid_ix_psk2(),
+        noise_hybrid_kk_psk0(),
+        noise_hybrid_kk_psk2(),
+        noise_hybrid_kn_psk0(),
+        noise_hybrid_kn_psk2(),
+        noise_hybrid_kx_psk2(),
+        noise_hybrid_nk_psk0(),
+        noise_hybrid_nk_psk2(),
+        noise_hybrid_nn_psk0(),
+        noise_hybrid_nn_psk2(),
+        noise_hybrid_nx_psk2(),
+        noise_hybrid_xk_psk3(),
+        noise_hybrid_xn_psk3(),
+        noise_hybrid_xx_psk3(),
+    ]
+}
+
+/// Setup NQ handshake pair
+pub fn setup_nq_handshake<DH: Dh, C: Cipher, H: Hash>(
+    pattern: &HandshakePattern,
+) -> (NqHandshake<DH, C, H>, NqHandshake<DH, C, H>) {
+    let alice_key = DH::genkey().unwrap();
+    let bob_key = DH::genkey().unwrap();
+    let alice_pub = alice_key.public.clone();
+    let bob_pub = bob_key.public.clone();
+
+    let mut alice = NqHandshake::<DH, C, H>::new(
+        pattern.clone(),
+        &[],
+        true,
+        Some(alice_key),
+        None,
+        Some(bob_pub),
+        None,
+    )
+    .unwrap();
+    let mut bob = NqHandshake::<DH, C, H>::new(
+        pattern.clone(),
+        &[],
+        false,
+        Some(bob_key),
+        None,
+        Some(alice_pub),
+        None,
+    )
+    .unwrap();
+
+    alice.push_psk(PSK);
+    bob.push_psk(PSK);
+
+    (alice, bob)
+}
+
+/// Setup PQ handshake pair
+pub fn setup_pq_handshake<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(
+    pattern: &HandshakePattern,
+) -> (PqHandshake<EKEM, SKEM, C, H>, PqHandshake<EKEM, SKEM, C, H>) {
+    let alice_key = SKEM::genkey().unwrap();
+    let bob_key = SKEM::genkey().unwrap();
+    let alice_pub = alice_key.public.clone();
+    let bob_pub = bob_key.public.clone();
+
+    let mut alice = PqHandshake::<EKEM, SKEM, C, H>::new(
+        pattern.clone(),
+        &[],
+        true,
+        Some(alice_key),
+        None,
+        Some(bob_pub),
+        None,
+    )
+    .unwrap();
+    let mut bob = PqHandshake::<EKEM, SKEM, C, H>::new(
+        pattern.clone(),
+        &[],
+        false,
+        Some(bob_key),
+        None,
+        Some(alice_pub),
+        None,
+    )
+    .unwrap();
+
+    alice.push_psk(PSK);
+    bob.push_psk(PSK);
+
+    (alice, bob)
+}
+
+/// Setup hybrid handshake pair
+pub fn setup_hybrid_handshake<DH: Dh, EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(
+    pattern: &HandshakePattern,
+) -> (HybridHandshake<DH, EKEM, SKEM, C, H>, HybridHandshake<DH, EKEM, SKEM, C, H>) {
+    let alice_dh_keys = DH::genkey().unwrap();
+    let alice_dh_pub = alice_dh_keys.public.clone();
+    let bob_dh_keys = DH::genkey().unwrap();
+    let bob_dh_pub = bob_dh_keys.public.clone();
+
+    let alice_kem_keys = SKEM::genkey().unwrap();
+    let alice_kem_pub = alice_kem_keys.public.clone();
+    let bob_kem_keys = SKEM::genkey().unwrap();
+    let bob_kem_pub = bob_kem_keys.public.clone();
+
+    let alice_params = HybridHandshakeParams::new(pattern.clone(), true)
+        .with_prologue(&[])
+        .with_s(alice_dh_keys)
+        .with_rs(bob_dh_pub)
+        .with_s_kem(alice_kem_keys)
+        .with_rs_kem(bob_kem_pub);
+
+    let mut alice = HybridHandshake::<DH, EKEM, SKEM, C, H>::new(alice_params).unwrap();
+
+    let bob_params = HybridHandshakeParams::new(pattern.clone(), false)
+        .with_prologue(&[])
+        .with_s(bob_dh_keys)
+        .with_rs(alice_dh_pub)
+        .with_s_kem(bob_kem_keys)
+        .with_rs_kem(alice_kem_pub);
+
+    let mut bob = HybridHandshake::<DH, EKEM, SKEM, C, H>::new(bob_params).unwrap();
+
+    alice.push_psk(PSK);
+    bob.push_psk(PSK);
+
+    (alice, bob)
+}
+
+/// Complete a handshake exchange between two parties
+pub fn complete_handshake<A: Handshaker<C, H>, B: Handshaker<C, H>, C: Cipher, H: Hash>(
+    mut alice: A,
+    mut bob: B,
+) -> (TransportState<C, H>, TransportState<C, H>) {
+    let mut alice_buf = [0u8; MAX_MESSAGE_LEN];
+    let mut bob_buf = [0u8; MAX_MESSAGE_LEN];
+
+    loop {
+        let n = alice.write_message(&[], &mut alice_buf).unwrap();
+        let _ = bob.read_message(&alice_buf[..n], &mut bob_buf).unwrap();
+
+        if alice.is_finished() && bob.is_finished() {
+            break;
+        }
+
+        let n = bob.write_message(&[], &mut bob_buf).unwrap();
+        let _ = alice.read_message(&bob_buf[..n], &mut alice_buf).unwrap();
+
+        if alice.is_finished() && bob.is_finished() {
+            break;
+        }
+    }
+
+    let alice_transport = alice.finalize().unwrap();
+    let bob_transport = bob.finalize().unwrap();
+
+    (alice_transport, bob_transport)
+}
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! ## Example
 //!
-//! Simplified example with the most straightforward (and unsecure) PQ handshake pattern and
+//! Simplified example with the most straightforward (and insecure) PQ handshake pattern and
 //! no handshake payload data at all:
 //!
 //! ```rust
@@ -157,7 +157,7 @@
 //!
 //! If you do not add `getrandom` support, Clatter can still be used. In this case you
 //! are restricted to the lower-level handshake core types, such as [`NqHandshakeCore`]
-//! and [`PqHandshakeCore`] and must implement your own custom RNG provides that implements
+//! and [`PqHandshakeCore`] and must implement your own custom RNG provider that implements
 //! the traits defined by [`crate::traits::Rng`].
 
 #[cfg(feature = "alloc")]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,3 +1,4 @@
+use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Hash};
 use clatter::Handshaker;
 
@@ -6,6 +7,118 @@ mod smoke;
 
 #[allow(unused)]
 mod no_getrandom_smoke;
+
+// Shared handshake pattern arrays for use in both smoke test files
+pub fn nq_handshake_patterns() -> Vec<HandshakePattern> {
+    vec![
+        noise_n(),
+        noise_k(),
+        noise_x(),
+        noise_ik(),
+        noise_in(),
+        noise_ix(),
+        noise_kk(),
+        noise_kn(),
+        noise_kx(),
+        noise_nk(),
+        noise_nn(),
+        noise_nx(),
+        noise_xk(),
+        noise_xn(),
+        noise_xx(),
+        noise_n_psk0(),
+        noise_k_psk0(),
+        noise_x_psk1(),
+        noise_ik_psk1(),
+        noise_ik_psk2(),
+        noise_in_psk1(),
+        noise_in_psk2(),
+        noise_ix_psk2(),
+        noise_kk_psk0(),
+        noise_kk_psk2(),
+        noise_kn_psk0(),
+        noise_kn_psk2(),
+        noise_kx_psk2(),
+        noise_nk_psk0(),
+        noise_nk_psk2(),
+        noise_nn_psk0(),
+        noise_nn_psk2(),
+        noise_nx_psk2(),
+        noise_xk_psk3(),
+        noise_xn_psk3(),
+        noise_xx_psk3(),
+    ]
+}
+
+pub fn pq_handshake_patterns() -> Vec<HandshakePattern> {
+    vec![
+        noise_pqik(),
+        noise_pqin(),
+        noise_pqix(),
+        noise_pqkk(),
+        noise_pqkn(),
+        noise_pqkx(),
+        noise_pqnk(),
+        noise_pqnn(),
+        noise_pqnx(),
+        noise_pqxk(),
+        noise_pqxn(),
+        noise_pqxx(),
+        noise_pqik_psk1(),
+        noise_pqik_psk2(),
+        noise_pqin_psk1(),
+        noise_pqin_psk2(),
+        noise_pqix_psk2(),
+        noise_pqkk_psk0(),
+        noise_pqkk_psk2(),
+        noise_pqkn_psk0(),
+        noise_pqkn_psk2(),
+        noise_pqkx_psk2(),
+        noise_pqnk_psk0(),
+        noise_pqnk_psk2(),
+        noise_pqnn_psk0(),
+        noise_pqnn_psk2(),
+        noise_pqnx_psk2(),
+        noise_pqxk_psk3(),
+        noise_pqxn_psk3(),
+        noise_pqxx_psk3(),
+    ]
+}
+
+pub fn hybrid_handshake_patterns() -> Vec<HandshakePattern> {
+    vec![
+        noise_hybrid_ik(),
+        noise_hybrid_in(),
+        noise_hybrid_ix(),
+        noise_hybrid_kk(),
+        noise_hybrid_kn(),
+        noise_hybrid_kx(),
+        noise_hybrid_nk(),
+        noise_hybrid_nn(),
+        noise_hybrid_nx(),
+        noise_hybrid_xk(),
+        noise_hybrid_xn(),
+        noise_hybrid_xx(),
+        noise_hybrid_ik_psk1(),
+        noise_hybrid_ik_psk2(),
+        noise_hybrid_in_psk1(),
+        noise_hybrid_in_psk2(),
+        noise_hybrid_ix_psk2(),
+        noise_hybrid_kk_psk0(),
+        noise_hybrid_kk_psk2(),
+        noise_hybrid_kn_psk0(),
+        noise_hybrid_kn_psk2(),
+        noise_hybrid_kx_psk2(),
+        noise_hybrid_nk_psk0(),
+        noise_hybrid_nk_psk2(),
+        noise_hybrid_nn_psk0(),
+        noise_hybrid_nn_psk2(),
+        noise_hybrid_nx_psk2(),
+        noise_hybrid_xk_psk3(),
+        noise_hybrid_xn_psk3(),
+        noise_hybrid_xx_psk3(),
+    ]
+}
 
 pub fn verify_handshake<A: Handshaker<C, H>, B: Handshaker<C, H>, C: Cipher, H: Hash>(
     mut alice: A,

--- a/tests/src/no_getrandom_smoke.rs
+++ b/tests/src/no_getrandom_smoke.rs
@@ -7,9 +7,14 @@ use clatter::crypto::hash::{Blake2b, Blake2s, Sha256, Sha512};
 use clatter::crypto::kem::{pqclean_ml_kem, rust_crypto_ml_kem};
 use clatter::handshakepattern::*;
 use clatter::traits::{Cipher, Dh, Hash, Kem};
-use clatter::{rand_core, DualLayerHandshake, Handshaker, NqHandshakeCore, PqHandshakeCore};
+use clatter::{
+    rand_core, DualLayerHandshake, Handshaker, HybridHandshakeCore, HybridHandshakeParams,
+    NqHandshakeCore, PqHandshakeCore,
+};
 
-use crate::verify_handshake;
+use crate::{
+    hybrid_handshake_patterns, nq_handshake_patterns, pq_handshake_patterns, verify_handshake,
+};
 
 const PSKS: &[[u8; 32]] = &[[0; 32], [1; 32], [2; 32], [3; 32]];
 
@@ -45,44 +50,7 @@ impl rand_core::CryptoRng for DummyRng {}
 
 #[test]
 fn no_getrandom_smoke_nq_handshakes() {
-    let handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
+    let handshakes = nq_handshake_patterns();
 
     for pattern in handshakes {
         no_getrandom_nq_handshake::<X25519, ChaChaPoly, Sha512>(pattern.clone());
@@ -99,38 +67,7 @@ fn no_getrandom_smoke_nq_handshakes() {
 
 #[test]
 fn no_getrandom_smoke_pq_handshakes() {
-    let handshakes = [
-        noise_pqik(),
-        noise_pqin(),
-        noise_pqix(),
-        noise_pqkk(),
-        noise_pqkn(),
-        noise_pqkx(),
-        noise_pqnk(),
-        noise_pqnn(),
-        noise_pqnx(),
-        noise_pqxk(),
-        noise_pqxn(),
-        noise_pqxx(),
-        noise_pqik_psk1(),
-        noise_pqik_psk2(),
-        noise_pqin_psk1(),
-        noise_pqin_psk2(),
-        noise_pqix_psk2(),
-        noise_pqkk_psk0(),
-        noise_pqkk_psk2(),
-        noise_pqkn_psk0(),
-        noise_pqkn_psk2(),
-        noise_pqkx_psk2(),
-        noise_pqnk_psk0(),
-        noise_pqnk_psk2(),
-        noise_pqnn_psk0(),
-        noise_pqnn_psk2(),
-        noise_pqnx_psk2(),
-        noise_pqxk_psk3(),
-        noise_pqxn_psk3(),
-        noise_pqxx_psk3(),
-    ];
+    let handshakes = pq_handshake_patterns();
 
     fn cipher_hash_combos<EKEM: Kem, SKEM: Kem>(pattern: HandshakePattern) {
         no_getrandom_pq_handshake::<EKEM, SKEM, ChaChaPoly, Blake2b>(pattern.clone());
@@ -169,78 +106,55 @@ fn no_getrandom_smoke_pq_handshakes() {
 }
 
 #[test]
-fn no_getrandom_smoke_dual_layer_handshakes() {
-    let nq_handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
+fn no_getrandom_smoke_hybrid_handshakes() {
+    let handshakes = hybrid_handshake_patterns();
 
-    let pq_handshakes = [
-        noise_pqik(),
-        noise_pqin(),
-        noise_pqix(),
-        noise_pqkk(),
-        noise_pqkn(),
-        noise_pqkx(),
-        noise_pqnk(),
-        noise_pqnn(),
-        noise_pqnx(),
-        noise_pqxk(),
-        noise_pqxn(),
-        noise_pqxx(),
-        noise_pqik_psk1(),
-        noise_pqik_psk2(),
-        noise_pqin_psk1(),
-        noise_pqin_psk2(),
-        noise_pqix_psk2(),
-        noise_pqkk_psk0(),
-        noise_pqkk_psk2(),
-        noise_pqkn_psk0(),
-        noise_pqkn_psk2(),
-        noise_pqkx_psk2(),
-        noise_pqnk_psk0(),
-        noise_pqnk_psk2(),
-        noise_pqnn_psk0(),
-        noise_pqnn_psk2(),
-        noise_pqnx_psk2(),
-        noise_pqxk_psk3(),
-        noise_pqxn_psk3(),
-        noise_pqxx_psk3(),
-    ];
+    fn cipher_hash_combos<DH: Dh, EKEM: Kem, SKEM: Kem>(pattern: HandshakePattern) {
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, ChaChaPoly, Blake2b>(pattern.clone());
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, ChaChaPoly, Blake2s>(pattern.clone());
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, ChaChaPoly, Sha256>(pattern.clone());
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, ChaChaPoly, Sha512>(pattern.clone());
+
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, AesGcm, Blake2b>(pattern.clone());
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, AesGcm, Blake2s>(pattern.clone());
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, AesGcm, Sha256>(pattern.clone());
+        no_getrandom_hybrid_handshake::<DH, EKEM, SKEM, AesGcm, Sha512>(pattern.clone());
+    }
+
+    for pattern in handshakes {
+        // Rust crypto
+        cipher_hash_combos::<X25519, rust_crypto_ml_kem::MlKem512, rust_crypto_ml_kem::MlKem512>(
+            pattern.clone(),
+        );
+        cipher_hash_combos::<X25519, rust_crypto_ml_kem::MlKem768, rust_crypto_ml_kem::MlKem768>(
+            pattern.clone(),
+        );
+        cipher_hash_combos::<X25519, rust_crypto_ml_kem::MlKem1024, rust_crypto_ml_kem::MlKem1024>(
+            pattern.clone(),
+        );
+
+        // PQCLean
+        cipher_hash_combos::<X25519, pqclean_ml_kem::MlKem512, pqclean_ml_kem::MlKem512>(
+            pattern.clone(),
+        );
+        cipher_hash_combos::<X25519, pqclean_ml_kem::MlKem768, pqclean_ml_kem::MlKem768>(
+            pattern.clone(),
+        );
+        cipher_hash_combos::<X25519, pqclean_ml_kem::MlKem1024, pqclean_ml_kem::MlKem1024>(
+            pattern.clone(),
+        );
+
+        // One cross-use test just in case with two different KEM vendors
+        cipher_hash_combos::<X25519, pqclean_ml_kem::MlKem768, rust_crypto_ml_kem::MlKem768>(
+            pattern.clone(),
+        );
+    }
+}
+
+#[test]
+fn no_getrandom_smoke_dual_layer_handshakes() {
+    let nq_handshakes = nq_handshake_patterns();
+    let pq_handshakes = pq_handshake_patterns();
 
     fn cipher_hash_combos<EKEM: Kem, SKEM: Kem, DH: Dh>(
         nq_pattern: HandshakePattern,
@@ -473,6 +387,48 @@ fn no_getrandom_pq_handshake<EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(pattern: 
         None,
     )
     .unwrap();
+
+    // Push PSKs every time. No harm done if the pattern doesn't use those.
+    for psk in PSKS {
+        alice.push_psk(psk);
+        bob.push_psk(psk);
+    }
+
+    verify_handshake(alice, bob);
+}
+
+fn no_getrandom_hybrid_handshake<DH: Dh, EKEM: Kem, SKEM: Kem, C: Cipher, H: Hash>(
+    pattern: HandshakePattern,
+) {
+    // Generate static keys
+    let alice_dh_keys = DH::genkey_rng(&mut DummyRng).unwrap();
+    let alice_dh_pub = alice_dh_keys.public.clone();
+    let bob_dh_keys = DH::genkey_rng(&mut DummyRng).unwrap();
+    let bob_dh_pub = bob_dh_keys.public.clone();
+
+    let alice_kem_keys = SKEM::genkey_rng(&mut DummyRng).unwrap();
+    let alice_kem_pub = alice_kem_keys.public.clone();
+    let bob_kem_keys = SKEM::genkey_rng(&mut DummyRng).unwrap();
+    let bob_kem_pub = bob_kem_keys.public.clone();
+
+    let alice_params = HybridHandshakeParams::new(pattern.clone(), true)
+        .with_prologue(b"Stumbling all around")
+        .with_s(alice_dh_keys)
+        .with_rs(bob_dh_pub)
+        .with_s_kem(alice_kem_keys)
+        .with_rs_kem(bob_kem_pub);
+
+    let mut alice =
+        HybridHandshakeCore::<DH, EKEM, SKEM, C, H, DummyRng>::new(alice_params).unwrap();
+
+    let bob_params = HybridHandshakeParams::new(pattern.clone(), false)
+        .with_prologue(b"Stumbling all around")
+        .with_s(bob_dh_keys)
+        .with_rs(alice_dh_pub)
+        .with_s_kem(bob_kem_keys)
+        .with_rs_kem(alice_kem_pub);
+
+    let mut bob = HybridHandshakeCore::<DH, EKEM, SKEM, C, H, DummyRng>::new(bob_params).unwrap();
 
     // Push PSKs every time. No harm done if the pattern doesn't use those.
     for psk in PSKS {

--- a/tests/src/smoke.rs
+++ b/tests/src/smoke.rs
@@ -9,50 +9,15 @@ use clatter::{
     HybridHandshakeParams, NqHandshake, PqHandshake,
 };
 
-use crate::verify_handshake;
+use crate::{
+    hybrid_handshake_patterns, nq_handshake_patterns, pq_handshake_patterns, verify_handshake,
+};
 
 const PSKS: &[[u8; 32]] = &[[0; 32], [1; 32], [2; 32], [3; 32]];
 
 #[test]
 fn smoke_nq_handshakes() {
-    let handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
+    let handshakes = nq_handshake_patterns();
 
     for pattern in handshakes {
         nq_handshake::<X25519, ChaChaPoly, Sha512>(pattern.clone());
@@ -69,38 +34,7 @@ fn smoke_nq_handshakes() {
 
 #[test]
 fn smoke_pq_handshakes() {
-    let handshakes = [
-        noise_pqik(),
-        noise_pqin(),
-        noise_pqix(),
-        noise_pqkk(),
-        noise_pqkn(),
-        noise_pqkx(),
-        noise_pqnk(),
-        noise_pqnn(),
-        noise_pqnx(),
-        noise_pqxk(),
-        noise_pqxn(),
-        noise_pqxx(),
-        noise_pqik_psk1(),
-        noise_pqik_psk2(),
-        noise_pqin_psk1(),
-        noise_pqin_psk2(),
-        noise_pqix_psk2(),
-        noise_pqkk_psk0(),
-        noise_pqkk_psk2(),
-        noise_pqkn_psk0(),
-        noise_pqkn_psk2(),
-        noise_pqkx_psk2(),
-        noise_pqnk_psk0(),
-        noise_pqnk_psk2(),
-        noise_pqnn_psk0(),
-        noise_pqnn_psk2(),
-        noise_pqnx_psk2(),
-        noise_pqxk_psk3(),
-        noise_pqxn_psk3(),
-        noise_pqxx_psk3(),
-    ];
+    let handshakes = pq_handshake_patterns();
 
     fn cipher_hash_combos<EKEM: Kem, SKEM: Kem>(pattern: HandshakePattern) {
         pq_handshake::<EKEM, SKEM, ChaChaPoly, Blake2b>(pattern.clone());
@@ -140,38 +74,7 @@ fn smoke_pq_handshakes() {
 
 #[test]
 fn smoke_hybrid_handshakes() {
-    let handshakes = [
-        noise_hybrid_ik(),
-        noise_hybrid_in(),
-        noise_hybrid_ix(),
-        noise_hybrid_kk(),
-        noise_hybrid_kn(),
-        noise_hybrid_kx(),
-        noise_hybrid_nk(),
-        noise_hybrid_nn(),
-        noise_hybrid_nx(),
-        noise_hybrid_xk(),
-        noise_hybrid_xn(),
-        noise_hybrid_xx(),
-        noise_hybrid_ik_psk1(),
-        noise_hybrid_ik_psk2(),
-        noise_hybrid_in_psk1(),
-        noise_hybrid_in_psk2(),
-        noise_hybrid_ix_psk2(),
-        noise_hybrid_kk_psk0(),
-        noise_hybrid_kk_psk2(),
-        noise_hybrid_kn_psk0(),
-        noise_hybrid_kn_psk2(),
-        noise_hybrid_kx_psk2(),
-        noise_hybrid_nk_psk0(),
-        noise_hybrid_nk_psk2(),
-        noise_hybrid_nn_psk0(),
-        noise_hybrid_nn_psk2(),
-        noise_hybrid_nx_psk2(),
-        noise_hybrid_xk_psk3(),
-        noise_hybrid_xn_psk3(),
-        noise_hybrid_xx_psk3(),
-    ];
+    let handshakes = hybrid_handshake_patterns();
 
     fn cipher_hash_combos<DH: Dh, EKEM: Kem, SKEM: Kem>(pattern: HandshakePattern) {
         hybrid_handshake::<DH, EKEM, SKEM, ChaChaPoly, Blake2b>(pattern.clone());
@@ -217,77 +120,8 @@ fn smoke_hybrid_handshakes() {
 
 #[test]
 fn smoke_dual_layer_handshakes() {
-    let nq_handshakes = [
-        noise_n(),
-        noise_k(),
-        noise_x(),
-        noise_ik(),
-        noise_in(),
-        noise_ix(),
-        noise_kk(),
-        noise_kn(),
-        noise_kx(),
-        noise_nk(),
-        noise_nn(),
-        noise_nx(),
-        noise_xk(),
-        noise_xn(),
-        noise_xx(),
-        noise_n_psk0(),
-        noise_k_psk0(),
-        noise_x_psk1(),
-        noise_ik_psk1(),
-        noise_ik_psk2(),
-        noise_in_psk1(),
-        noise_in_psk2(),
-        noise_ix_psk2(),
-        noise_kk_psk0(),
-        noise_kk_psk2(),
-        noise_kn_psk0(),
-        noise_kn_psk2(),
-        noise_kx_psk2(),
-        noise_nk_psk0(),
-        noise_nk_psk2(),
-        noise_nn_psk0(),
-        noise_nn_psk2(),
-        noise_nx_psk2(),
-        noise_xk_psk3(),
-        noise_xn_psk3(),
-        noise_xx_psk3(),
-    ];
-
-    let pq_handshakes = [
-        noise_pqik(),
-        noise_pqin(),
-        noise_pqix(),
-        noise_pqkk(),
-        noise_pqkn(),
-        noise_pqkx(),
-        noise_pqnk(),
-        noise_pqnn(),
-        noise_pqnx(),
-        noise_pqxk(),
-        noise_pqxn(),
-        noise_pqxx(),
-        noise_pqik_psk1(),
-        noise_pqik_psk2(),
-        noise_pqin_psk1(),
-        noise_pqin_psk2(),
-        noise_pqix_psk2(),
-        noise_pqkk_psk0(),
-        noise_pqkk_psk2(),
-        noise_pqkn_psk0(),
-        noise_pqkn_psk2(),
-        noise_pqkx_psk2(),
-        noise_pqnk_psk0(),
-        noise_pqnk_psk2(),
-        noise_pqnn_psk0(),
-        noise_pqnn_psk2(),
-        noise_pqnx_psk2(),
-        noise_pqxk_psk3(),
-        noise_pqxn_psk3(),
-        noise_pqxx_psk3(),
-    ];
+    let nq_handshakes = nq_handshake_patterns();
+    let pq_handshakes = pq_handshake_patterns();
 
     fn cipher_hash_combos<EKEM: Kem, SKEM: Kem, DH: Dh>(
         nq_pattern: HandshakePattern,


### PR DESCRIPTION
* Restructured smoke tests and fuzz tests to reduce repetition
* Increased test coverage to include proper testing for hybrid handshakes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors fuzz and smoke tests to shared helpers, adds hybrid handshake fuzz targets and tests, fixes docs/README typos, and bumps crate version to 2.1.0-rc.2.
> 
> - **Tests**:
>   - Centralize handshake pattern lists and verification utilities in `tests/src/lib.rs`; update `smoke.rs` and `no_getrandom_smoke.rs` to use them and add comprehensive hybrid handshake coverage.
> - **Fuzzing**:
>   - Introduce shared fuzz utilities in `fuzz/src/lib.rs` and expose as `clatter_fuzz` library; refactor existing NQ/PQ fuzz targets to use helpers.
>   - Add new hybrid fuzz targets: `fuzz_targets/hybrid_handshake_read.rs`, `hybrid_handshake_payload.rs`, and `hybrid_transport.rs` with corresponding bins in `fuzz/Cargo.toml`.
> - **Docs**:
>   - Fix typos and wording in `README.md` and `src/lib.rs` (e.g., "ephemeral", "insecure", RNG provider phrasing).
> - **Version**:
>   - Bump `clatter` crate version to `2.1.0-rc.2` in `Cargo.toml` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e4ee0f7a01036e262d6510ec3c4a637e5d3b89d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->