### PR TITLE
Expose SymmetricState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "clatter"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clatter"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 rust-version = "1.81.0"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Noise_pqNN_MLKEM512+Kyber768_ChaChaPoly_BLAKE2s
 Clatter provides ready-made hybrid handshake types. Below is the formal specification of those handshake mechanisms while
 the [crate documentation](https://docs.rs/clatter/latest/clatter/) provides practical details.
 
-### [`HybridHandshake`](https://docs.rs/clatter/latest/clatter/struct.HybridHandshake.html)
+### [`HybridHandshake`](https://docs.rs/clatter/latest/clatter/type.HybridHandshake.html)
 
 A *true hybrid* handshake which combines both DH and KEM operations. This handshake type accepts handshake patterns with
 both DH and KEM operations and mixes the results of both exchanges in a single *symmetric state* containing the session

--- a/examples/custom_crypto.rs
+++ b/examples/custom_crypto.rs
@@ -31,11 +31,8 @@ impl clatter::traits::CryptoComponent for MySillyHash {
 
 impl clatter::traits::Hash for MySillyHash {
     // Most of the crypto traits by clatter have type parameters, which
-    // indicate some static sizing qualities of the algorithms. These types
-    // usually have to implement `clatter::bytearray::ByteArray` but implementations
-    // for the most common static array sizes are built-in.
+    // indicate some static sizing qualities of the algorithms.
     type Block = [u8; 32];
-    // ..But you can also use any size with the help of ArrayVec (stack allocated).
     // Here we are also using `SensitiveByteArray`, a wrapper provided
     // by Clatter, which is zeroized on drop.
     type Output = SensitiveByteArray<ArrayVec<u8, 32>>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,8 @@ pub enum CipherError {
     Decrypt,
     /// Encrypt error
     Encrypt,
+    /// Missing key material
+    MissingKeyMaterial,
 }
 
 /// Cipher operation result type

--- a/src/handshakestate/dual_layer.rs
+++ b/src/handshakestate/dual_layer.rs
@@ -1,4 +1,6 @@
-use crate::error::HandshakeResult;
+use crate::cipherstate::CipherStates;
+use crate::error::{CipherResult, HandshakeResult};
+use crate::symmetricstate::SymmetricState;
 use crate::traits::{Cipher, Handshaker, HandshakerInternal, Hash};
 use crate::transportstate::TransportState;
 
@@ -175,7 +177,7 @@ where
         }
     }
 
-    fn get_ciphers(&self) -> crate::cipherstate::CipherStates<C> {
+    fn get_ciphers(&self) -> CipherResult<CipherStates<C>> {
         self.inner.get_ciphers()
     }
 
@@ -251,5 +253,15 @@ where
     /// Get remote ephemeral key of the **inner** handshake (if available)
     fn get_remote_ephemeral(&self) -> Option<Self::E> {
         self.inner.get_remote_ephemeral()
+    }
+
+    /// Get a copy of the **inner** handshakers current [`SymmetricState`]
+    fn get_state(&self) -> SymmetricState<C, H> {
+        self.inner.get_state()
+    }
+
+    /// Get a mutable reference of the **inner** handshakers current [`SymmetricState`]
+    fn get_state_mut(&mut self) -> &mut SymmetricState<C, H> {
+        self.inner.get_state_mut()
     }
 }

--- a/src/handshakestate/hybrid.rs
+++ b/src/handshakestate/hybrid.rs
@@ -8,7 +8,7 @@ use super::HandshakeInternals;
 use crate::bytearray::ByteArray;
 use crate::cipherstate::CipherStates;
 use crate::constants::{MAX_PSKS, PSK_LEN};
-use crate::error::{HandshakeError, HandshakeResult};
+use crate::error::{CipherResult, HandshakeError, HandshakeResult};
 use crate::handshakepattern::{HandshakePattern, HandshakeType, Token};
 use crate::handshakestate::HandshakeStatus;
 use crate::symmetricstate::SymmetricState;
@@ -704,7 +704,7 @@ where
         Ok(out_len)
     }
 
-    fn get_ciphers(&self) -> CipherStates<C> {
+    fn get_ciphers(&self) -> CipherResult<CipherStates<C>> {
         self.dh_internals.get_ciphers()
     }
 
@@ -843,5 +843,13 @@ where
             (Some(dh), Some(kem)) => Some(HybridPubKeyPair::new(dh.clone(), kem.clone())),
             _ => None,
         }
+    }
+
+    fn get_state(&self) -> SymmetricState<C, H> {
+        self.dh_internals.symmetricstate.clone()
+    }
+
+    fn get_state_mut(&mut self) -> &mut SymmetricState<C, H> {
+        &mut self.dh_internals.symmetricstate
     }
 }

--- a/src/handshakestate/hybrid_dual_layer.rs
+++ b/src/handshakestate/hybrid_dual_layer.rs
@@ -1,6 +1,8 @@
 use crate::bytearray::ByteArray;
+use crate::cipherstate::CipherStates;
 use crate::constants::HYBRID_DUAL_LAYER_HANDSHAKE_DOMAIN;
-use crate::error::HandshakeResult;
+use crate::error::{CipherResult, HandshakeResult};
+use crate::symmetricstate::SymmetricState;
 use crate::traits::{Cipher, Handshaker, HandshakerInternal, Hash};
 use crate::transportstate::TransportState;
 
@@ -184,7 +186,7 @@ where
         }
     }
 
-    fn get_ciphers(&self) -> crate::cipherstate::CipherStates<C> {
+    fn get_ciphers(&self) -> CipherResult<CipherStates<C>> {
         self.inner.get_ciphers()
     }
 
@@ -260,5 +262,15 @@ where
     /// Get remote ephemeral key of the **inner** handshake (if available)
     fn get_remote_ephemeral(&self) -> Option<Self::E> {
         self.inner.get_remote_ephemeral()
+    }
+
+    /// Get a copy of the **inner** handshakers current [`SymmetricState`]
+    fn get_state(&self) -> SymmetricState<C, H> {
+        self.inner.get_state()
+    }
+
+    /// Get a mutable reference of the **inner** handshakers current [`SymmetricState`]
+    fn get_state_mut(&mut self) -> &mut SymmetricState<C, H> {
+        self.inner.get_state_mut()
     }
 }

--- a/src/handshakestate/mod.rs
+++ b/src/handshakestate/mod.rs
@@ -4,7 +4,7 @@ use zeroize::Zeroize;
 use crate::bytearray::ByteArray;
 use crate::cipherstate::CipherStates;
 use crate::constants::{MAX_PSKS, PSK_LEN};
-use crate::error::{HandshakeError, HandshakeResult};
+use crate::error::{CipherResult, HandshakeError, HandshakeResult};
 use crate::handshakepattern::{HandshakePattern, Token};
 use crate::symmetricstate::SymmetricState;
 use crate::traits::{Cipher, Hash, Rng};
@@ -113,7 +113,7 @@ where
         self.symmetricstate.get_hash()
     }
 
-    pub(crate) fn get_ciphers(&self) -> CipherStates<C> {
+    pub(crate) fn get_ciphers(&self) -> CipherResult<CipherStates<C>> {
         self.symmetricstate.split()
     }
 

--- a/src/handshakestate/nq.rs
+++ b/src/handshakestate/nq.rs
@@ -6,8 +6,9 @@ use arrayvec::{ArrayString, ArrayVec};
 
 use super::HandshakeInternals;
 use crate::bytearray::ByteArray;
+use crate::cipherstate::CipherStates;
 use crate::constants::{MAX_PSKS, PSK_LEN};
-use crate::error::{HandshakeError, HandshakeResult};
+use crate::error::{CipherResult, HandshakeError, HandshakeResult};
 use crate::handshakepattern::{HandshakePattern, HandshakeType, Token};
 use crate::handshakestate::HandshakeStatus;
 use crate::symmetricstate::SymmetricState;
@@ -390,7 +391,7 @@ where
         Ok(out_len)
     }
 
-    fn get_ciphers(&self) -> crate::cipherstate::CipherStates<C> {
+    fn get_ciphers(&self) -> CipherResult<CipherStates<C>> {
         self.internals.get_ciphers()
     }
 
@@ -489,5 +490,13 @@ where
 
     fn get_remote_ephemeral(&self) -> Option<Self::E> {
         self.internals.re.clone()
+    }
+
+    fn get_state(&self) -> SymmetricState<C, H> {
+        self.internals.symmetricstate.clone()
+    }
+
+    fn get_state_mut(&mut self) -> &mut SymmetricState<C, H> {
+        &mut self.internals.symmetricstate
     }
 }

--- a/src/handshakestate/pq.rs
+++ b/src/handshakestate/pq.rs
@@ -8,7 +8,7 @@ use super::HandshakeInternals;
 use crate::bytearray::ByteArray;
 use crate::cipherstate::CipherStates;
 use crate::constants::{MAX_PSKS, PSK_LEN};
-use crate::error::{HandshakeError, HandshakeResult};
+use crate::error::{CipherResult, HandshakeError, HandshakeResult};
 use crate::handshakepattern::{HandshakePattern, HandshakeType, Token};
 use crate::handshakestate::HandshakeStatus;
 use crate::symmetricstate::SymmetricState;
@@ -419,7 +419,7 @@ where
         Ok(out_len)
     }
 
-    fn get_ciphers(&self) -> CipherStates<C> {
+    fn get_ciphers(&self) -> CipherResult<CipherStates<C>> {
         self.internals.get_ciphers()
     }
 
@@ -547,5 +547,13 @@ where
 
     fn get_remote_ephemeral(&self) -> Option<Self::E> {
         self.internals.re.clone()
+    }
+
+    fn get_state(&self) -> SymmetricState<C, H> {
+        self.internals.symmetricstate.clone()
+    }
+
+    fn get_state_mut(&mut self) -> &mut SymmetricState<C, H> {
+        &mut self.internals.symmetricstate
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ mod crypto_impl;
 pub mod error;
 pub mod handshakepattern;
 mod handshakestate;
-mod symmetricstate;
+pub mod symmetricstate;
 pub mod traits;
 pub mod transportstate;
 

--- a/src/symmetricstate.rs
+++ b/src/symmetricstate.rs
@@ -7,7 +7,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::bytearray::ByteArray;
 use crate::cipherstate::{CipherState, CipherStates};
-use crate::error::CipherResult;
+use crate::error::{CipherError, CipherResult};
 use crate::traits::{Cipher, Hash};
 
 /// Symmetric state used during handshakes to establish session hash and chaining key
@@ -28,7 +28,7 @@ where
     H: Hash,
 {
     /// Initialize new symmetric state for the given Noise protocol type
-    pub(crate) fn new(noise_pattern_name: &str) -> Self {
+    pub fn new(noise_pattern_name: &str) -> Self {
         let pattern_bytes = noise_pattern_name.as_bytes();
         let mut h = H::Output::new_zero();
 
@@ -46,29 +46,44 @@ where
         }
     }
 
+    /// Initialize new symmetric state with zeroed key material
+    pub fn new_zero() -> Self {
+        Self {
+            cipherstate: None,
+            ck: H::Output::new_zero(),
+            h: H::Output::new_zero(),
+        }
+    }
+
+    /// Mix hash material into the symmetric state
+    ///
     /// # Protocol
     /// ```text
     /// Sets h = HASH(h || data)
     /// ```
-    pub(crate) fn mix_hash(&mut self, bytes: &[u8]) {
+    pub fn mix_hash(&mut self, data: &[u8]) {
         let mut h = H::default();
         h.input(self.h.as_slice());
-        h.input(bytes);
+        h.input(data);
         self.h = h.result();
     }
 
+    /// Mix key material into the symmetric state
+    ///
     /// # Protocol
     /// ```text
     /// * Sets ck, temp_k = HKDF(ck, input_key_material, 2).
     /// * If HASHLEN is 64, then truncates temp_k to 32 bytes.
     /// * Calls InitializeKey(temp_k).
     /// ```
-    pub(crate) fn mix_key(&mut self, input_key_material: &[u8]) {
+    pub fn mix_key(&mut self, input_key_material: &[u8]) {
         let (ck, temp_k) = H::hkdf(self.ck.as_slice(), input_key_material);
         self.ck = ck;
         self.cipherstate = Some(CipherState::new(&temp_k.as_slice()[..C::key_len()], 0));
     }
 
+    /// Mix key and hash material into the symmetric state
+    ///
     /// # Protocol
     /// ```text
     /// * Sets ck, temp_h, temp_k = HKDF(ck, input_key_material, 3).
@@ -76,7 +91,7 @@ where
     /// * If HASHLEN is 64, then truncates temp_k to 32 bytes.
     /// * Calls InitializeKey(temp_k).
     /// ```
-    pub(crate) fn mix_key_and_hash(&mut self, input_key_material: &[u8]) {
+    pub fn mix_key_and_hash(&mut self, input_key_material: &[u8]) {
         let (ck, temp_h, temp_k) = H::hkdf3(self.ck.as_slice(), input_key_material);
         self.ck = ck;
         self.mix_hash(temp_h.as_slice());
@@ -87,11 +102,10 @@ where
     ///
     /// # Warning
     /// If no key material is available, `plaintext` is simply copied to the `out` buffer
-    pub(crate) fn encrypt_and_hash(
-        &mut self,
-        plaintext: &[u8],
-        out: &mut [u8],
-    ) -> CipherResult<()> {
+    ///
+    /// # Errors
+    /// * [CipherError] - Cipher related error from the implementation level
+    pub fn encrypt_and_hash(&mut self, plaintext: &[u8], out: &mut [u8]) -> CipherResult<()> {
         if let Some(ref mut c) = self.cipherstate {
             c.encrypt_with_ad(self.h.as_slice(), plaintext, out)?;
         } else {
@@ -105,7 +119,10 @@ where
     ///
     /// # Warning
     /// If no key material is available, `data` is simply copied to the `out` buffer
-    pub(crate) fn decrypt_and_hash(&mut self, data: &[u8], out: &mut [u8]) -> CipherResult<()> {
+    ///
+    /// # Errors
+    /// * [CipherError] - Cipher related error from the implementation level
+    pub fn decrypt_and_hash(&mut self, data: &[u8], out: &mut [u8]) -> CipherResult<()> {
         if let Some(ref mut c) = self.cipherstate {
             c.decrypt_with_ad(self.h.as_slice(), data, out)?;
         } else {
@@ -117,12 +134,11 @@ where
 
     /// Return [`CipherStates`] for encrypting and decrypting transport messages
     ///
-    /// # Panics
-    /// * If no key material has been established
-    pub(crate) fn split(&self) -> CipherStates<C> {
-        // This means that we are still in the initial state
-        if self.ck == self.h {
-            panic!("No key material")
+    /// # Errors
+    /// * [`CipherError::MissingKeyMaterial`] - No key material has been established
+    pub fn split(&self) -> CipherResult<CipherStates<C>> {
+        if !self.has_key() {
+            return Err(CipherError::MissingKeyMaterial);
         }
 
         let (mut temp_k1, mut temp_k2) = H::hkdf(self.ck.as_slice(), &[]);
@@ -134,16 +150,21 @@ where
 
         temp_k1.zeroize();
         temp_k2.zeroize();
-        ct
+        Ok(ct)
     }
 
-    /// Get handshake hash
-    pub(crate) fn get_hash(&self) -> H::Output {
+    /// Get symmetric state hash `h`
+    pub fn get_hash(&self) -> H::Output {
         self.h.clone()
     }
 
-    /// Check if have already established key material
-    pub(crate) fn has_key(&self) -> bool {
+    /// Get symmetric state chaining key `ck`
+    pub fn get_chaining_key(&self) -> H::Output {
+        self.ck.clone()
+    }
+
+    /// Check if the symmetric state has already established key material
+    pub fn has_key(&self) -> bool {
         self.cipherstate.is_some()
     }
 }
@@ -210,8 +231,8 @@ mod tests {
         assert!(s1 == s2);
 
         // Split
-        let s1_c = s1.split();
-        let s2_c = s2.split();
+        let s1_c = s1.split().unwrap();
+        let s2_c = s2.split().unwrap();
 
         assert!(s1_c.initiator_to_responder.take() == s2_c.initiator_to_responder.take());
         assert!(s1_c.responder_to_initiator.take() == s2_c.responder_to_initiator.take());
@@ -236,11 +257,10 @@ mod tests {
         cant_split_without_key::<C, H>();
     }
 
-    #[should_panic]
     fn cant_split_without_key<C: Cipher, H: Hash>() {
         let mut s1 = SymmetricState::<C, H>::new("complex delirium");
         s1.mix_hash(b"all wound up");
-        s1.split();
+        assert!(s1.split().is_err());
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,6 +10,7 @@ use crate::constants::{MAX_KEY_LEN, MAX_MESSAGE_LEN, MAX_TAG_LEN};
 use crate::error::{CipherResult, DhResult, HandshakeError, HandshakeResult, KemResult};
 use crate::handshakepattern::HandshakePattern;
 use crate::handshakestate::HandshakeStatus;
+use crate::symmetricstate::SymmetricState;
 use crate::transportstate::TransportState;
 use crate::KeyPair;
 
@@ -279,7 +280,7 @@ where
     /// Read next handshake message
     fn read_message_impl(&mut self, message: &[u8], out: &mut [u8]) -> HandshakeResult<usize>;
     /// Extract ciphers
-    fn get_ciphers(&self) -> CipherStates<C>;
+    fn get_ciphers(&self) -> CipherResult<CipherStates<C>>;
     /// Get handshake hash `h`
     fn get_hash(&self) -> H::Output;
     /// Mix data into the handshake hash `h`
@@ -460,4 +461,10 @@ where
     {
         TransportState::new(self)
     }
+
+    /// Get a copy of the handshakers current [`SymmetricState`]
+    fn get_state(&self) -> SymmetricState<C, H>;
+
+    /// Get a mutable reference of the handshakers current [`SymmetricState`]
+    fn get_state_mut(&mut self) -> &mut SymmetricState<C, H>;
 }

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -42,7 +42,7 @@ impl<C: Cipher, H: Hash> TransportState<C, H> {
 
         Ok(TransportState {
             pattern: hs.get_pattern(),
-            cipherstates: hs.get_ciphers(),
+            cipherstates: hs.get_ciphers()?,
             h: hs.get_hash(),
             initiator: hs.is_initiator(),
         })


### PR DESCRIPTION
* Make SymmetricState public
* Add accessors in handshakers to extract SymmetricState
* Replace an unnecessary panic with a proper error in SymmetricState
* Update some comments to relfect the current state of the implementation
* Fix broken documentation link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces public access to the handshake symmetric state and replaces a panic with proper error handling across cipher extraction.
> 
> - **Public API:** Expose `pub mod symmetricstate`; make `SymmetricState::{new, mix_hash, mix_key, mix_key_and_hash, encrypt_and_hash, decrypt_and_hash, split, get_hash}` public; add `new_zero` and `get_chaining_key`.
> - **State accessors:** Add `Handshaker::{get_state, get_state_mut}` and implement in `nq`, `pq`, `hybrid`, `dual_layer`, and `hybrid_dual_layer` handshakes.
> - **Error handling:** Add `CipherError::MissingKeyMaterial`; make `SymmetricState::split` return `CipherResult<CipherStates>`; change `HandshakerInternal::get_ciphers` to return `CipherResult`; propagate to `TransportState::new` and handshake implementations (use `?`).
> - **Docs:** Fix broken `HybridHandshake` docs link and update comments in example.
> - **Version:** Bump crate to `2.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b7961f9d7a60df192e7dd158f11125c1191a2d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->