### PR TITLE
Add PR check for no_std compatibility

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,4 +1,7 @@
 name: PR-tests
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -54,3 +54,15 @@ jobs:
 
       - name: Audit
         run: cargo audit
+
+  no_std_check:
+    name: Verify no_std compatibility on thumbv7em-none-eabihf reference target
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install thumbv7em-none-eabihf reference target
+        run: rustup target add thumbv7em-none-eabihf
+
+      - name: Check
+        run: cargo check --no-default-features --features=core --target thumbv7em-none-eabihf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,22 @@ std = [
     "getrandom",
 ]
 
+core = [
+    "use-aes-gcm",
+    "use-chacha20poly1305",
+    "use-sha",
+    "use-blake2",
+    "use-25519",
+    "use-rust-crypto-ml-kem",
+]
+
 getrandom = ["dep:getrandom"]
 
 use-sha = ["sha2"]
 use-blake2 = ["blake2"]
 use-aes-gcm = ["aes-gcm"]
 use-chacha20poly1305 = ["chacha20poly1305"]
-use-pqclean-ml-kem = ["pqcrypto-mlkem", "pqcrypto-traits"]
+use-pqclean-ml-kem = ["pqcrypto-mlkem", "pqcrypto-traits", "getrandom"]
 use-rust-crypto-ml-kem = ["ml-kem"]
 use-25519 = ["x25519-dalek"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! | `use-sha`                 | Enable SHA-256 and SHA-512 hashing                    | yes       |                                                                   |
 //! | `use-blake2`              | Enable BLAKE2 hashing                                 | yes       |                                                                   |
 //! | `use-rust-crypto-ml-kem`  | Enable ML-KEM (Kyber) KEMs by RustCrypto              | yes       |                                                                   |
-//! | `use-pqclean-ml-kem`      | Enable ML-KEM (Kyber) KEMs by PQClean                 | yes       |                                                                   |
+//! | `use-pqclean-ml-kem`      | Enable ML-KEM (Kyber) KEMs by PQClean                 | yes       | Requires `getrandom`                                              |
 //! | `std`                     | Enable standard library support                       | yes       | Enables `std` for supported dependencies                          |
 //! | `alloc`                   | Enable allocator support                              | yes       | Enables dynamically sized buffer types in [`crate::bytearray`]    |
 //! | `getrandom`               | Enable automatic system RNG support via [`getrandom`] | yes       | Can be used without `std`                                         |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds CI coverage for `no_std` builds and aligns features/docs.
> 
> - New GitHub Actions job `no_std_check` validates `thumbv7em-none-eabihf` with `cargo check --no-default-features --features=core`; workflow now declares explicit `permissions`
> - Introduces `core` feature in `Cargo.toml` to bundle core crypto options for `no_std` checks
> - Updates `use-pqclean-ml-kem` feature to include `getrandom`; docs now note it "Requires `getrandom`"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0823f85514bf7422ac257fedaba593f60d5410f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->