### PR TITLE
Eliminate responder's unused KEM ephemeral key from hybrid handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,12 @@ following the ordering rule stated by PQNoise:
 #### Tokens `e` and `s` handling
 
 Handshake pattern tokens `e` and `s` require special handling for sending/receiving both the DH and KEM public keys.
-Clatter will always place the public DH key first in the message buffer, followed by the public KEM key. All the related
+Except as noted below, Clatter will always place the public DH key first in the message buffer, followed by the public KEM key. All the related
 `mix_hash` and `mix_key` operations are also conducted in the same order.
+
+Exception: If `ekem` precedes `e` in the same message, `e` carries only the DH public key. The KEM public key is
+omitted, since the ephemeral KEM exchange has already been completed by `ekem` using the peer's previously received
+KEM public key. This avoids transmitting an otherwise unused ephemeral KEM public key.
 
 #### Hybrid protocol naming scheme
 

--- a/src/handshakestate/hybrid.rs
+++ b/src/handshakestate/hybrid.rs
@@ -128,23 +128,30 @@ where
     }
 }
 
-/// Container for a pair of public keys used by the hybrid handshake
+/// Container for a pair of public keys used by the hybrid handshake.
+///
+/// `kem` is optional because a peer may not have a KEM public key
+/// (e.g. when it encapsulates via `Ekem` instead).
 pub struct HybridPubKeyPair<D, K> {
     dh: D,
-    kem: K,
+    kem: Option<K>,
 }
 
 impl<D, K> HybridPubKeyPair<D, K> {
     pub fn new(dh: D, kem: K) -> HybridPubKeyPair<D, K> {
-        Self { dh, kem }
+        Self { dh, kem: Some(kem) }
+    }
+
+    fn dh_only(dh: D) -> HybridPubKeyPair<D, K> {
+        Self { dh, kem: None }
     }
 
     pub fn dh(&self) -> &D {
         &self.dh
     }
 
-    pub fn kem(&self) -> &K {
-        &self.kem
+    pub fn kem(&self) -> Option<&K> {
+        self.kem.as_ref()
     }
 }
 
@@ -162,6 +169,8 @@ pub type HybridHandshake<DH, EKEM, SKEM, C, H> =
 ///
 /// This handshake type accepts handshake patterns with both DH and KEM operations.
 /// [`Token::E`]/[`Token::S`] will send/receive both DH and KEM ephemeral/static public keys.
+/// When [`Token::Ekem`] precedes [`Token::E`] in the same message, the KEM public key
+/// portion of `E` is omitted since the KEM ephemeral exchange is already complete.
 #[derive(Clone)]
 pub struct HybridHandshakeCore<DH, EKEM, SKEM, C, H, RNG>
 where
@@ -455,15 +464,13 @@ where
         };
 
         let mut cur = 0_usize;
+        let mut ekem_present = false;
         for token in message {
             match *token {
                 Token::E => {
-                    // Generate both DH and KEM ephemeral keys if not present
+                    // Generate DH ephemeral key if not present
                     if self.dh_internals.e.is_none() {
                         self.dh_internals.e = Some(DH::genkey_rng(&mut self.dh_internals.rng)?);
-                    }
-                    if self.kem_e.is_none() {
-                        self.kem_e = Some(EKEM::genkey_rng(&mut self.dh_internals.rng)?);
                     }
 
                     // Send DH public key
@@ -475,18 +482,30 @@ where
                     out[cur..cur + DH::PubKey::len()].copy_from_slice(e_pub.as_slice());
                     cur += DH::PubKey::len();
 
-                    // Send KEM public key
-                    let e_kem_pub = &self.kem_e.as_ref().unwrap().public;
-                    self.dh_internals
-                        .symmetricstate
-                        .mix_hash(e_kem_pub.as_slice());
-                    if self.get_pattern().has_psk() {
+                    // Generate and send KEM public key only when Ekem has not
+                    // already been processed in this message. When ekem_present
+                    // is true the KEM ephemeral exchange is already complete
+                    // and the KEM public key is redundant. Per the token
+                    // ordering convention (see README), if ekem is present in a
+                    // message it always precedes e, so checking ekem_present
+                    // before processing e is sufficient.
+                    if !ekem_present {
+                        if self.kem_e.is_none() {
+                            self.kem_e = Some(EKEM::genkey_rng(&mut self.dh_internals.rng)?);
+                        }
+
+                        let e_kem_pub = &self.kem_e.as_ref().unwrap().public;
                         self.dh_internals
                             .symmetricstate
-                            .mix_key(e_kem_pub.as_slice());
+                            .mix_hash(e_kem_pub.as_slice());
+                        if self.get_pattern().has_psk() {
+                            self.dh_internals
+                                .symmetricstate
+                                .mix_key(e_kem_pub.as_slice());
+                        }
+                        out[cur..cur + EKEM::PubKey::len()].copy_from_slice(e_kem_pub.as_slice());
+                        cur += EKEM::PubKey::len();
                     }
-                    out[cur..cur + EKEM::PubKey::len()].copy_from_slice(e_kem_pub.as_slice());
-                    cur += EKEM::PubKey::len();
 
                     // Sending E satisfies the requirement of applying self-chosen randomness
                     self.dh_internals.own_randomness_applied = true;
@@ -552,6 +571,7 @@ where
                     self.dh_internals.symmetricstate.mix_key(ss.as_slice());
                     out[cur..cur + EKEM::Ct::len()].copy_from_slice(ct.as_slice());
                     cur += EKEM::Ct::len();
+                    ekem_present = true;
 
                     // Sending Ekem satisfies the requirement of applying self-chosen randomness
                     self.dh_internals.own_randomness_applied = true;
@@ -629,6 +649,7 @@ where
             self.dh_internals.initiator_pattern_index += 1;
             p
         };
+        let mut ekem_present = false;
 
         for token in message_pattern {
             match *token {
@@ -641,13 +662,16 @@ where
                     }
                     self.dh_internals.re = Some(re);
 
-                    // Receive KEM public key
-                    let re_kem = EKEM::PubKey::from_slice(get(EKEM::PubKey::len()));
-                    self.dh_internals.symmetricstate.mix_hash(re_kem.as_slice());
-                    if self.get_pattern().has_psk() {
-                        self.dh_internals.symmetricstate.mix_key(re_kem.as_slice());
+                    // Receive KEM public key only when Ekem has not already been
+                    // processed in this message (see write_message_impl comment).
+                    if !ekem_present {
+                        let re_kem = EKEM::PubKey::from_slice(get(EKEM::PubKey::len()));
+                        self.dh_internals.symmetricstate.mix_hash(re_kem.as_slice());
+                        if self.get_pattern().has_psk() {
+                            self.dh_internals.symmetricstate.mix_key(re_kem.as_slice());
+                        }
+                        self.kem_re = Some(re_kem);
                     }
-                    self.kem_re = Some(re_kem);
                 }
                 Token::S => {
                     let has_key = self.dh_internals.symmetricstate.has_key();
@@ -696,6 +720,7 @@ where
                     self.dh_internals.symmetricstate.mix_hash(ct);
                     let ss = EKEM::decapsulate(ct, self.kem_e.as_ref().unwrap().secret.as_slice())?;
                     self.dh_internals.symmetricstate.mix_key(ss.as_slice());
+                    ekem_present = true;
                 }
                 Token::Skem => {
                     let len = if self.dh_internals.symmetricstate.has_key() {
@@ -779,12 +804,17 @@ where
         let mut overhead = 0;
         let mut has_key = self.dh_internals.has_key();
         let has_psk = self.get_pattern().has_psk();
+        let mut ekem_present = false;
 
         for &token in message {
             match token {
                 Token::E => {
                     overhead += DH::PubKey::len();
-                    overhead += EKEM::PubKey::len();
+                    // KEM public key is omitted when Ekem already appeared
+                    // in this message (see write_message_impl comment).
+                    if !ekem_present {
+                        overhead += EKEM::PubKey::len();
+                    }
                     if has_psk {
                         has_key = true;
                     }
@@ -802,6 +832,7 @@ where
                 Token::Ekem => {
                     overhead += EKEM::Ct::len();
                     has_key = true;
+                    ekem_present = true;
                 }
                 Token::Skem => {
                     overhead += SKEM::Ct::len();
@@ -863,10 +894,12 @@ where
     }
 
     fn get_remote_ephemeral(&self) -> Option<Self::E> {
-        match (self.dh_internals.re.as_ref(), self.kem_re.as_ref()) {
-            (Some(dh), Some(kem)) => Some(HybridPubKeyPair::new(dh.clone(), kem.clone())),
-            _ => None,
-        }
+        self.dh_internals.re.as_ref().map(|dh| {
+            match self.kem_re.as_ref() {
+                Some(kem) => HybridPubKeyPair::new(dh.clone(), kem.clone()),
+                None => HybridPubKeyPair::dh_only(dh.clone()),
+            }
+        })
     }
 
     fn get_state(&self) -> SymmetricState<C, H> {


### PR DESCRIPTION
Hi!

I would like to propose a PR for issue #27. When `Ekem` is present, `E` can omit generation of the ephemeral KEM public key, since that key is never encapsulated against by the peer.

## Problem

The `E` token carries both DH (X25519) and KEM (ML-KEM) ephemeral public keys. But in patterns like `<- ekem, e, ee`, the `E` token's KEM public key is never used — the only `Ekem` in the pattern encapsulates against the *initiator's* KEM key from a prior message. The responder's KEM public key is dead weight on the wire and in the symmetric state.

For `noise_hybrid_nn_psk0` with ML-KEM-768:

```
Before:
  Message 1 (1232 bytes): X25519 e_pub | ML-KEM-768 e_pub | AEAD tag
  Message 2 (2320 bytes): ML-KEM-768 ct | X25519 e_pub | ML-KEM-768 e_pub | AEAD tag
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^
                                                    1184 bytes — unused

After:
  Message 1 (1232 bytes): X25519 e_pub | ML-KEM-768 e_pub | AEAD tag
  Message 2 (1136 bytes): ML-KEM-768 ct | X25519 e_pub | AEAD tag
                           (1184 bytes saved)
```

## Rationale

Per the token ordering convention documented in the README ("Within a message `ekem` always precedes `skem` which always precedes all public keys and the payload"), if `ekem` is present in a message it always precedes `e`. When the responder's message contains both `ekem` and `e` (e.g., `<- ekem, e, ee`), the `ekem` token is processed first and encapsulates against the initiator's KEM key from message 1. By the time `e` is processed, the KEM ephemeral exchange is already complete, so `e`'s KEM component is redundant.

## Changes

An `ekem_present` flag is tracked across the token loop in three places:

- **`write_message_impl`**: After `Ekem` is sent, the flag is set. The subsequent `E` token skips generating the KEM keypair, writing the KEM public key, and mixing it into the symmetric state.
- **`read_message_impl`**: After `Ekem` is received, the flag is set. The subsequent `E` token skips reading the KEM public key from the wire and mixing it into the symmetric state.
- **`get_next_message_overhead`**: After `Ekem` appears in the token list, the flag is set. The subsequent `E` token does not count `EKEM::PubKey::len()` toward the message overhead.

`HybridPubKeyPair.kem` is now `Option<K>` to correctly represent the case where a peer completes its KEM key exchange without sending a KEM public key. `get_remote_ephemeral` returns `Some` when the DH key is present, even if the KEM key is missing.

The `S`/`Skem` tokens for static keys are unaffected.

## Breaking change

This changes the handshake wire format and symmetric state for all `noise_hybrid_*` patterns. Handshakes between pre- and post-change implementations will produce different symmetric states and fail to establish a shared secret. Both sides must be updated together.

## Verification

Run `cargo run --example` [`hybrid_wire_format`](https://gist.github.com/Gowee/2582990fcedbfd58e0e8ca6a6315ae02#file-hybrid_wire_format_after-rs) to see the wire layout. All 46 existing tests pass.
